### PR TITLE
feat: TypeScript SDK & Frontend Integration Library

### DIFF
--- a/predictx-sdk/README.md
+++ b/predictx-sdk/README.md
@@ -1,0 +1,224 @@
+# @predictx/sdk
+
+TypeScript SDK for the **PredictX** decentralised football prediction market on Stellar / Soroban.
+
+## Installation
+
+```bash
+npm install @predictx/sdk
+# or
+yarn add @predictx/sdk
+```
+
+## Quick Start
+
+```ts
+import {
+  PredictXClient,
+  StakeSide,
+  VoteChoice,
+  formatTokenAmount,
+} from "@predictx/sdk";
+
+const client = new PredictXClient({
+  network: "testnet",
+  contractIds: {
+    predictionMarket: "CXXX...",
+    votingOracle:     "CYYY...",
+    treasury:         "CZZZ...",
+    pollFactory:      "CWWW...",
+  },
+});
+
+// Connect a wallet (e.g. Freighter)
+await client.connect({
+  publicKey: "GABC...",
+  signTransaction: (xdr, network) => freighter.signTransaction(xdr, { network }),
+});
+
+// Browse polls for a match
+const polls = await client.getPollsByMatch(1);
+
+// Stake 10 tokens on YES
+const result = await client.stake(polls[0].pollId, 100_000_000n, StakeSide.Yes);
+console.log("Staked! tx:", result.hash);
+
+// Preview potential winnings before staking
+const winnings = await client.calculatePotentialWinnings(
+  polls[0].pollId,
+  StakeSide.Yes,
+  100_000_000n,
+);
+console.log("If you win:", formatTokenAmount(winnings));
+```
+
+## API Reference
+
+### `PredictXClient`
+
+The main entry point. Aggregates all contract clients.
+
+#### Connection
+
+| Method | Description |
+|--------|-------------|
+| `connect(wallet)` | Connect a Stellar wallet |
+| `connectedAddress` | Public key of connected wallet |
+
+#### Matches
+
+| Method | Description |
+|--------|-------------|
+| `getMatch(matchId)` | Fetch a single match |
+| `getUpcomingMatches()` | All non-finished matches |
+| `createMatch(params)` | Create a match (admin) |
+
+#### Polls
+
+| Method | Description |
+|--------|-------------|
+| `getPoll(pollId)` | Fetch a single poll |
+| `getPollsByMatch(matchId)` | All polls for a match |
+| `getTrendingPolls(limit?)` | Top polls by pool size |
+| `createPoll(params)` | Create a new poll |
+
+#### Staking
+
+| Method | Description |
+|--------|-------------|
+| `stake(pollId, amount, side)` | Place a stake |
+| `getStake(pollId, user?)` | Get user's stake on a poll |
+| `getUserStakes(user?)` | All poll IDs user has staked on |
+| `calculatePotentialWinnings(pollId, side, amount)` | Preview winnings |
+
+#### Claims
+
+| Method | Description |
+|--------|-------------|
+| `claimWinnings(pollId)` | Claim winnings (resolved polls) |
+| `calculateWinnings(pollId, user?)` | View claimable amount |
+
+#### Voting
+
+| Method | Description |
+|--------|-------------|
+| `castVote(pollId, choice)` | Vote on a locked poll |
+| `getVoteTally(pollId)` | Current vote tally |
+| `getVotingOpportunities(user?)` | Polls open for voting (non-stakers) |
+| `claimVotingReward(pollId)` | Claim voter incentive |
+
+#### Stats
+
+| Method | Description |
+|--------|-------------|
+| `getPlatformStats()` | Aggregate platform statistics |
+| `getUserStats(user?)` | Per-user statistics |
+| `getUserHistory(user?)` | Full prediction history |
+
+#### Events
+
+| Method | Description |
+|--------|-------------|
+| `subscribeToEvents(callback)` | Subscribe to real-time events; returns unsubscribe fn |
+
+---
+
+### Utility Functions
+
+```ts
+import {
+  calculatePotentialWinnings,
+  formatTokenAmount,
+  parseTokenAmount,
+  truncateAddress,
+  formatCountdown,
+} from "@predictx/sdk";
+
+// Client-side winnings preview (no RPC needed)
+const { winnings, profit, roi } = calculatePotentialWinnings(
+  100_000_000n,  // your stake
+  "yes",
+  1_000_000_000n, // current YES pool
+  1_000_000_000n, // current NO pool
+);
+
+// Format raw base units → "10.0000000"
+formatTokenAmount(100_000_000n);
+
+// Parse "10.5" → 105_000_000n
+parseTokenAmount("10.5");
+
+// "GABCDE…WXYZ"
+truncateAddress("GABCDEFGHIJKLMNOPQRSTUVWXYZ...");
+
+// "2h 15m"
+formatCountdown(new Date(Date.now() + 2 * 3600 * 1000));
+```
+
+---
+
+### Error Handling
+
+All SDK errors are instances of `PredictXError` with a typed `code` property:
+
+```ts
+import { PredictXError, PredictXErrorCode } from "@predictx/sdk";
+
+try {
+  await client.stake(pollId, amount, StakeSide.Yes);
+} catch (err) {
+  if (err instanceof PredictXError) {
+    switch (err.code) {
+      case PredictXErrorCode.AlreadyStaked:
+        // User already staked on this poll
+        break;
+      case PredictXErrorCode.StakeBelowMinimum:
+        // Stake is below the 10-token minimum
+        break;
+      case PredictXErrorCode.ContractPaused:
+        // Protocol is paused
+        break;
+    }
+  }
+}
+```
+
+---
+
+### Real-time Events
+
+```ts
+const unsubscribe = client.subscribeToEvents((event) => {
+  if (event.type === "stake:placed") {
+    console.log(`New stake on poll ${event.pollId}: ${event.amount}`);
+  }
+  if (event.type === "poll:created") {
+    console.log(`New poll: "${event.question}"`);
+  }
+});
+
+// Stop listening
+unsubscribe();
+```
+
+---
+
+## Token Amounts
+
+All token amounts use `bigint` with **7 decimal places** (like Stellar's XLM):
+
+- 1 token = `10_000_000n`
+- Minimum stake = `10_000_000n` (10 tokens)
+
+Use `formatTokenAmount` / `parseTokenAmount` to convert between raw and display values.
+
+## Browser & Node.js
+
+The SDK ships as both CJS and ESM bundles and has no DOM dependencies, so it works in:
+- Node.js ≥ 18
+- Modern browsers (Chrome, Firefox, Safari, Edge)
+- React, Vue, Next.js, etc.
+
+## License
+
+MIT

--- a/predictx-sdk/jest.config.js
+++ b/predictx-sdk/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/tests"],
+  testMatch: ["**/*.test.ts"],
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  coverageReporters: ["text", "lcov"],
+};

--- a/predictx-sdk/package.json
+++ b/predictx-sdk/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@predictx/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for PredictX decentralized prediction market on Stellar",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch",
+    "lint": "eslint src tests --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "stellar",
+    "soroban",
+    "predictx",
+    "prediction-market",
+    "blockchain",
+    "sdk"
+  ],
+  "author": "PredictX Contributors",
+  "license": "MIT",
+  "dependencies": {
+    "@stellar/stellar-sdk": "^13.0.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "tsup": "^8.0.2",
+    "typescript": "^5.4.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/predictx-sdk/src/client.ts
+++ b/predictx-sdk/src/client.ts
@@ -1,0 +1,597 @@
+/**
+ * PredictX SDK — Top-level `PredictXClient`.
+ *
+ * Aggregates all contract clients into a single entrypoint and provides
+ * the higher-level methods used by the frontend (poll cards, staking modal,
+ * dashboard, voting centre, real-time events).
+ */
+
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+import type {
+  Match,
+  Poll,
+  Stake,
+  StakeSide,
+  VoteChoice,
+  VoteTally,
+  PlatformStats,
+  UserStats,
+  PredictionHistoryEntry,
+  StellarWallet,
+  TransactionResult,
+  CreateMatchParams,
+  CreatePollParams,
+  PredictXConfig,
+  EventCallback,
+  Unsubscribe,
+  NetworkName,
+} from "./types/index";
+import { PollStatus } from "./types/index";
+
+import { PredictionMarketClient } from "./contracts/prediction-market";
+import { VotingOracleClient } from "./contracts/voting-oracle";
+import { TreasuryClient } from "./contracts/treasury";
+import { PollFactoryClient } from "./contracts/poll-factory";
+import { parseEvent } from "./events/parser";
+import { calculatePotentialWinnings } from "./utils/calculations";
+
+// Default RPC endpoints per network
+const DEFAULT_RPC_URLS: Record<NetworkName, string> = {
+  mainnet: "https://horizon.stellar.org",
+  testnet: "https://soroban-testnet.stellar.org",
+  futurenet: "https://rpc-futurenet.stellar.org",
+  standalone: "http://localhost:8000/soroban/rpc",
+};
+
+/**
+ * The unified PredictX SDK client.
+ *
+ * @example
+ * ```ts
+ * import { PredictXClient } from "@predictx/sdk";
+ *
+ * const client = new PredictXClient({
+ *   network: "testnet",
+ *   contractIds: {
+ *     predictionMarket: "CXXX...",
+ *     votingOracle:     "CYYY...",
+ *     treasury:         "CZZZ...",
+ *     pollFactory:      "CWWW...",
+ *   },
+ * });
+ *
+ * // Connect a wallet (e.g. Freighter)
+ * await client.connect(myWallet);
+ *
+ * // Read data
+ * const polls = await client.getPollsByMatch(1);
+ *
+ * // Submit a stake
+ * const result = await client.stake(pollId, 100_000_000n, StakeSide.Yes);
+ * ```
+ */
+export class PredictXClient {
+  private readonly predictionMarket: PredictionMarketClient;
+  private readonly votingOracle: VotingOracleClient;
+  private readonly treasury: TreasuryClient;
+  private readonly pollFactory: PollFactoryClient;
+  private readonly rpcUrl: string;
+  private readonly network: NetworkName;
+  private wallet: StellarWallet | null = null;
+
+  constructor(config: PredictXConfig) {
+    const rpcUrl =
+      config.rpcUrl ?? DEFAULT_RPC_URLS[config.network];
+
+    this.rpcUrl = rpcUrl;
+    this.network = config.network;
+
+    const baseConfig = { network: config.network, rpcUrl };
+
+    this.predictionMarket = new PredictionMarketClient({
+      ...baseConfig,
+      contractId: config.contractIds.predictionMarket,
+    });
+    this.votingOracle = new VotingOracleClient({
+      ...baseConfig,
+      contractId: config.contractIds.votingOracle,
+    });
+    this.treasury = new TreasuryClient({
+      ...baseConfig,
+      contractId: config.contractIds.treasury,
+    });
+    this.pollFactory = new PollFactoryClient({
+      ...baseConfig,
+      contractId: config.contractIds.pollFactory,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Connection
+  // -------------------------------------------------------------------------
+
+  /**
+   * Connects a Stellar wallet (e.g. Freighter) to the client.
+   * Must be called before any state-mutating operation.
+   *
+   * @param wallet - A StellarWallet implementation.
+   */
+  async connect(wallet: StellarWallet): Promise<void> {
+    this.wallet = wallet;
+  }
+
+  /** Returns the currently connected wallet's public key, or null. */
+  get connectedAddress(): string | null {
+    return this.wallet?.publicKey ?? null;
+  }
+
+  private requireWallet(): StellarWallet {
+    if (!this.wallet) {
+      throw new Error(
+        "No wallet connected. Call connect(wallet) before submitting transactions.",
+      );
+    }
+    return this.wallet;
+  }
+
+  // -------------------------------------------------------------------------
+  // Matches
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches a single match.
+   *
+   * @param matchId - The match ID.
+   */
+  async getMatch(matchId: number): Promise<Match> {
+    return this.predictionMarket.getMatch(matchId);
+  }
+
+  /**
+   * Returns all matches up to the current match count.
+   * Useful for building a match list / lobby.
+   */
+  async getUpcomingMatches(): Promise<Match[]> {
+    const count = await this.predictionMarket.getMatchCount();
+    const ids = Array.from({ length: count }, (_, i) => i + 1);
+    const results = await Promise.allSettled(
+      ids.map((id) => this.predictionMarket.getMatch(id)),
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<Match> => r.status === "fulfilled")
+      .map((r) => r.value)
+      .filter((m) => !m.isFinished);
+  }
+
+  /**
+   * Creates a new match (admin only).
+   */
+  async createMatch(
+    params: CreateMatchParams,
+  ): Promise<TransactionResult<number>> {
+    return this.predictionMarket.createMatch(params, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Polls
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches a single poll.
+   *
+   * @param pollId - The poll ID.
+   */
+  async getPoll(pollId: number): Promise<Poll> {
+    return this.predictionMarket.getPoll(pollId);
+  }
+
+  /**
+   * Returns all polls linked to a given match.
+   *
+   * @param matchId - The match ID.
+   */
+  async getPollsByMatch(matchId: number): Promise<Poll[]> {
+    const pollIds = await this.predictionMarket.getMatchPolls(matchId);
+    const results = await Promise.allSettled(
+      pollIds.map((id) => this.predictionMarket.getPoll(id)),
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<Poll> => r.status === "fulfilled")
+      .map((r) => r.value);
+  }
+
+  /**
+   * Returns the most active polls sorted by total pool size.
+   *
+   * @param limit - Maximum number of polls to return (default 10).
+   */
+  async getTrendingPolls(limit = 10): Promise<Poll[]> {
+    const stats = await this.predictionMarket.getPlatformStats();
+    const totalPolls = stats.totalPollsCreated;
+    const ids = Array.from({ length: Number(totalPolls) }, (_, i) => i + 1);
+
+    const results = await Promise.allSettled(
+      ids.map((id) => this.predictionMarket.getPoll(id)),
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<Poll> => r.status === "fulfilled")
+      .map((r) => r.value)
+      .filter((p) => p.status === PollStatus.Active)
+      .sort((a, b) =>
+        Number(b.yesPool + b.noPool - a.yesPool - a.noPool),
+      )
+      .slice(0, limit);
+  }
+
+  /**
+   * Creates a new prediction poll.
+   *
+   * @param params  - Poll parameters.
+   */
+  async createPoll(
+    params: CreatePollParams,
+  ): Promise<TransactionResult<number>> {
+    return this.predictionMarket.createPoll(params, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Staking
+  // -------------------------------------------------------------------------
+
+  /**
+   * Places a stake on a poll.
+   *
+   * @param pollId - Target poll.
+   * @param amount - Amount in raw base units (bigint).
+   * @param side   - StakeSide.Yes or StakeSide.No.
+   */
+  async stake(
+    pollId: number,
+    amount: bigint,
+    side: StakeSide,
+  ): Promise<TransactionResult<Stake>> {
+    return this.predictionMarket.stake(pollId, amount, side, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  /**
+   * Returns the stake a user has placed on a poll, or null if not staked.
+   *
+   * @param pollId - The poll ID.
+   * @param user   - Stellar address (defaults to connected wallet).
+   */
+  async getStake(pollId: number, user?: string): Promise<Stake | null> {
+    const address = user ?? this.connectedAddress;
+    if (!address) return null;
+    const hasStaked = await this.predictionMarket.hasUserStaked(
+      pollId,
+      address,
+    );
+    if (!hasStaked) return null;
+    return this.predictionMarket.getStakeInfo(pollId, address);
+  }
+
+  /**
+   * Returns the poll IDs on which a user has staked.
+   *
+   * @param user - Stellar address (defaults to connected wallet).
+   */
+  async getUserStakes(user?: string): Promise<number[]> {
+    const address = user ?? this.connectedAddress;
+    if (!address) return [];
+    return this.predictionMarket.getUserStakes(address);
+  }
+
+  /**
+   * Client-side preview of potential winnings for a proposed stake.
+   *
+   * @param pollId - The poll to stake on.
+   * @param side   - StakeSide.Yes or StakeSide.No.
+   * @param amount - Hypothetical stake amount (base units).
+   */
+  async calculatePotentialWinnings(
+    pollId: number,
+    side: StakeSide,
+    amount: bigint,
+  ): Promise<bigint> {
+    return this.predictionMarket.calculatePotentialWinnings(
+      pollId,
+      side,
+      amount,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Claims
+  // -------------------------------------------------------------------------
+
+  /**
+   * Claims winnings for a resolved poll.
+   *
+   * @param pollId - The resolved poll.
+   */
+  async claimWinnings(pollId: number): Promise<TransactionResult<bigint>> {
+    return this.predictionMarket.claimWinnings(pollId, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  /**
+   * Calculates claimable winnings (post-resolution view).
+   *
+   * @param pollId - The resolved poll.
+   * @param user   - Stellar address (defaults to connected wallet).
+   */
+  async calculateWinnings(
+    pollId: number,
+    user?: string,
+  ): Promise<bigint> {
+    const address = user ?? this.connectedAddress;
+    if (!address) return 0n;
+
+    const stake = await this.getStake(pollId, address);
+    if (!stake || stake.claimed) return 0n;
+
+    return this.predictionMarket.calculatePotentialWinnings(
+      pollId,
+      stake.side,
+      stake.amount,
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Voting
+  // -------------------------------------------------------------------------
+
+  /**
+   * Casts a vote on a locked poll.
+   *
+   * @param pollId - The poll to vote on.
+   * @param choice - VoteChoice.Yes, .No, or .Unclear.
+   */
+  async castVote(
+    pollId: number,
+    choice: VoteChoice,
+  ): Promise<TransactionResult<VoteTally>> {
+    return this.votingOracle.castVote(pollId, choice, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  /**
+   * Returns the current vote tally for a poll.
+   *
+   * @param pollId - The poll ID.
+   */
+  async getVoteTally(pollId: number): Promise<VoteTally> {
+    return this.votingOracle.getVoteTally(pollId);
+  }
+
+  /**
+   * Returns polls that are in the Voting phase (eligible for the connected
+   * wallet to vote on, provided they are not a staker).
+   *
+   * @param user - Stellar address (defaults to connected wallet).
+   */
+  async getVotingOpportunities(user?: string): Promise<Poll[]> {
+    const address = user ?? this.connectedAddress;
+    const stats = await this.predictionMarket.getPlatformStats();
+    const totalPolls = Number(stats.totalPollsCreated);
+    const ids = Array.from({ length: totalPolls }, (_, i) => i + 1);
+
+    const results = await Promise.allSettled(
+      ids.map((id) => this.predictionMarket.getPoll(id)),
+    );
+    const votingPolls = results
+      .filter((r): r is PromiseFulfilledResult<Poll> => r.status === "fulfilled")
+      .map((r) => r.value)
+      .filter((p) => p.status === PollStatus.Voting);
+
+    if (!address) return votingPolls;
+
+    // Filter out polls where the user is already a staker
+    const stakeChecks = await Promise.allSettled(
+      votingPolls.map((p) =>
+        this.predictionMarket.hasUserStaked(p.pollId, address),
+      ),
+    );
+    return votingPolls.filter(
+      (_, i) =>
+        stakeChecks[i].status === "fulfilled" &&
+        !(stakeChecks[i] as PromiseFulfilledResult<boolean>).value,
+    );
+  }
+
+  /**
+   * Claims the voting reward for a correctly-voted resolved poll.
+   *
+   * @param pollId - The resolved poll.
+   */
+  async claimVotingReward(
+    pollId: number,
+  ): Promise<TransactionResult<bigint>> {
+    return this.votingOracle.claimVotingReward(pollId, {
+      wallet: this.requireWallet(),
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Stats
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns aggregate platform statistics.
+   */
+  async getPlatformStats(): Promise<PlatformStats> {
+    return this.predictionMarket.getPlatformStats();
+  }
+
+  /**
+   * Computes per-user statistics by scanning the user's stake history.
+   *
+   * @param user - Stellar address (defaults to connected wallet).
+   */
+  async getUserStats(user?: string): Promise<UserStats> {
+    const address = user ?? this.connectedAddress;
+    if (!address) {
+      return {
+        totalStaked: 0n,
+        totalWon: 0n,
+        totalLost: 0n,
+        pollsParticipated: 0,
+        pollsWon: 0,
+        pollsLost: 0,
+        votesCast: 0,
+        votingRewardsEarned: 0n,
+      };
+    }
+
+    const pollIds = await this.predictionMarket.getUserStakes(address);
+    const entries = await this.getUserHistory(address);
+
+    let totalStaked = 0n;
+    let totalWon = 0n;
+    let totalLost = 0n;
+    let pollsWon = 0;
+    let pollsLost = 0;
+
+    for (const entry of entries) {
+      totalStaked += entry.amount;
+      if (entry.status === PollStatus.Resolved) {
+        if (entry.winnings && entry.winnings > 0n) {
+          totalWon += entry.winnings;
+          pollsWon++;
+        } else if (entry.outcome !== undefined) {
+          totalLost += entry.amount;
+          pollsLost++;
+        }
+      }
+    }
+
+    return {
+      totalStaked,
+      totalWon,
+      totalLost,
+      pollsParticipated: pollIds.length,
+      pollsWon,
+      pollsLost,
+      votesCast: 0, // Voting ledger not yet exposed in Phase 1
+      votingRewardsEarned: 0n,
+    };
+  }
+
+  /**
+   * Returns the user's full prediction history.
+   *
+   * @param user - Stellar address (defaults to connected wallet).
+   */
+  async getUserHistory(user?: string): Promise<PredictionHistoryEntry[]> {
+    const address = user ?? this.connectedAddress;
+    if (!address) return [];
+
+    const pollIds = await this.predictionMarket.getUserStakes(address);
+    const results = await Promise.allSettled(
+      pollIds.map(async (pollId) => {
+        const [poll, stake] = await Promise.all([
+          this.predictionMarket.getPoll(pollId),
+          this.predictionMarket.getStakeInfo(pollId, address),
+        ]);
+
+        let winnings: bigint | undefined;
+        if (
+          poll.status === PollStatus.Resolved &&
+          poll.outcome !== undefined
+        ) {
+          const onWinningSide =
+            (poll.outcome && stake.side === 0) ||
+            (!poll.outcome && stake.side === 1);
+          if (onWinningSide && !stake.claimed) {
+            winnings = await this.predictionMarket.calculatePotentialWinnings(
+              pollId,
+              stake.side,
+              stake.amount,
+            );
+          }
+        }
+
+        return {
+          pollId: poll.pollId,
+          question: poll.question,
+          side: stake.side,
+          amount: stake.amount,
+          outcome: poll.outcome,
+          winnings,
+          status: poll.status,
+          stakedAt: stake.stakedAt,
+        } satisfies PredictionHistoryEntry;
+      }),
+    );
+
+    return results
+      .filter(
+        (r): r is PromiseFulfilledResult<PredictionHistoryEntry> =>
+          r.status === "fulfilled",
+      )
+      .map((r) => r.value);
+  }
+
+  // -------------------------------------------------------------------------
+  // Real-time events
+  // -------------------------------------------------------------------------
+
+  /**
+   * Subscribes to PredictX contract events via Soroban RPC streaming.
+   * Returns an unsubscribe function — call it to stop receiving events.
+   *
+   * @param callback - Called for each parsed PredictXEvent.
+   *
+   * @example
+   * ```ts
+   * const unsubscribe = client.subscribeToEvents((event) => {
+   *   if (event.type === "stake:placed") {
+   *     console.log("New stake:", event.staker, event.amount);
+   *   }
+   * });
+   * // Later:
+   * unsubscribe();
+   * ```
+   */
+  subscribeToEvents(callback: EventCallback): Unsubscribe {
+    const server = new SorobanRpc.Server(this.rpcUrl, { allowHttp: true });
+    let active = true;
+    let latestLedger = 0;
+
+    const poll = async () => {
+      if (!active) return;
+      try {
+        // Fetch events from the latest known ledger onwards
+        const response = await (server as any).getEvents({
+          startLedger: latestLedger > 0 ? latestLedger : undefined,
+          filters: [{ type: "contract" }],
+          limit: 100,
+        });
+        for (const raw of response?.events ?? []) {
+          const event = parseEvent(raw);
+          if (event) callback(event);
+        }
+        if (response?.latestLedger) {
+          latestLedger = response.latestLedger + 1;
+        }
+      } catch {
+        // Non-fatal: network hiccup, retry next poll
+      }
+      if (active) setTimeout(poll, 5_000);
+    };
+
+    poll();
+    return () => {
+      active = false;
+    };
+  }
+}

--- a/predictx-sdk/src/contracts/poll-factory.ts
+++ b/predictx-sdk/src/contracts/poll-factory.ts
@@ -1,0 +1,192 @@
+/**
+ * PredictX SDK — PollFactory contract client.
+ *
+ * Creates standalone polls (not linked to a match).
+ */
+
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  xdr,
+  scValToNative,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+import type {
+  Poll,
+  PollCategory,
+  StellarWallet,
+  TransactionResult,
+  NetworkName,
+} from "../types/index";
+import { parseSorobanError } from "../errors";
+
+const NETWORK_PASSPHRASE: Record<NetworkName, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+  standalone: Networks.STANDALONE,
+};
+
+function toDate(unixSecs: unknown): Date {
+  return new Date(Number(unixSecs) * 1000);
+}
+
+function rawToPoll(raw: Record<string, unknown>): Poll {
+  return {
+    pollId: Number(raw["poll_id"]),
+    matchId: Number(raw["match_id"] ?? 0),
+    creator: String(raw["creator"]),
+    question: String(raw["question"]),
+    category: Number(raw["category"]) as PollCategory,
+    lockTime: toDate(raw["lock_time"]),
+    yesPool: BigInt(String(raw["yes_pool"] ?? 0)),
+    noPool: BigInt(String(raw["no_pool"] ?? 0)),
+    yesCount: Number(raw["yes_count"] ?? 0),
+    noCount: Number(raw["no_count"] ?? 0),
+    status: Number(raw["status"] ?? 0),
+    outcome: raw["outcome"] != null ? Boolean(raw["outcome"]) : undefined,
+    resolutionTime: raw["resolution_time"] != null
+      ? toDate(raw["resolution_time"])
+      : undefined,
+    createdAt: toDate(raw["created_at"] ?? 0),
+  };
+}
+
+interface InvokeOptions {
+  wallet: StellarWallet;
+  fee?: string;
+}
+
+/**
+ * Client for the `poll-factory` contract.
+ */
+export class PollFactoryClient {
+  private readonly contract: Contract;
+  private readonly server: SorobanRpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(config: {
+    contractId: string;
+    network: NetworkName;
+    rpcUrl: string;
+  }) {
+    this.contract = new Contract(config.contractId);
+    this.server = new SorobanRpc.Server(config.rpcUrl, { allowHttp: true });
+    this.networkPassphrase = NETWORK_PASSPHRASE[config.network];
+  }
+
+  private async simulate<T>(method: string, ...args: xdr.ScVal[]): Promise<T> {
+    try {
+      const account = await this.server.getAccount(
+        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      );
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+      return scValToNative(sim.result!.retval) as T;
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  private async invoke<T>(
+    method: string,
+    options: InvokeOptions,
+    ...args: xdr.ScVal[]
+  ): Promise<TransactionResult<T>> {
+    try {
+      const account = await this.server.getAccount(options.wallet.publicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: options.fee ?? BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+
+      const prepared = SorobanRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await options.wallet.signTransaction(
+        prepared.toXDR(),
+        this.networkPassphrase,
+      );
+      const submitted = await this.server.sendTransaction(
+        TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase),
+      );
+
+      if (submitted.status === "ERROR") {
+        throw new Error(`Transaction failed: ${submitted.errorResult}`);
+      }
+
+      let getResponse = await this.server.getTransaction(submitted.hash);
+      while (
+        getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND
+      ) {
+        await new Promise((r) => setTimeout(r, 1000));
+        getResponse = await this.server.getTransaction(submitted.hash);
+      }
+
+      const returnValue = getResponse.returnValue
+        ? (scValToNative(getResponse.returnValue) as T)
+        : (undefined as T);
+
+      return {
+        value: returnValue,
+        hash: submitted.hash,
+        ledger: getResponse.ledger,
+      };
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  /**
+   * Creates a standalone poll (not linked to any match).
+   *
+   * @param question       - Poll question (max 256 chars).
+   * @param lockTime       - When staking closes.
+   * @param options        - Wallet + fee options.
+   */
+  async createPoll(
+    question: string,
+    lockTime: Date,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<number>> {
+    const result = await this.invoke<bigint>(
+      "create_poll",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(question, { type: "string" }),
+      nativeToScVal(Math.floor(lockTime.getTime() / 1000), { type: "u64" }),
+    );
+    return { ...result, value: Number(result.value) };
+  }
+
+  /**
+   * Fetches a standalone poll by ID.
+   */
+  async getPoll(pollId: number): Promise<Poll> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_poll",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return rawToPoll(raw);
+  }
+}

--- a/predictx-sdk/src/contracts/prediction-market.ts
+++ b/predictx-sdk/src/contracts/prediction-market.ts
@@ -1,0 +1,565 @@
+/**
+ * PredictX SDK — PredictionMarket contract client.
+ *
+ * Wraps all `prediction-market` contract invocations in typed,
+ * ergonomic methods.  Read operations use `simulateTransaction`;
+ * write operations build, sign, and submit a full transaction.
+ */
+
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  xdr,
+  scValToNative,
+  nativeToScVal,
+  Address,
+  type Keypair,
+} from "@stellar/stellar-sdk";
+
+import type {
+  Match,
+  Poll,
+  Stake,
+  PoolInfo,
+  PlatformStats,
+  PollCategory,
+  StakeSide,
+  StellarWallet,
+  TransactionResult,
+  CreateMatchParams,
+  CreatePollParams,
+  NetworkName,
+} from "../types/index";
+import { parseSorobanError } from "../errors";
+import { calculatePotentialWinnings } from "../utils/calculations";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const NETWORK_PASSPHRASE: Record<NetworkName, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+  standalone: Networks.STANDALONE,
+};
+
+function toDate(unixSecs: unknown): Date {
+  return new Date(Number(unixSecs) * 1000);
+}
+
+function rawToMatch(raw: Record<string, unknown>): Match {
+  return {
+    matchId: Number(raw["match_id"]),
+    homeTeam: String(raw["home_team"]),
+    awayTeam: String(raw["away_team"]),
+    league: String(raw["league"]),
+    venue: String(raw["venue"]),
+    kickoffTime: toDate(raw["kickoff_time"]),
+    createdBy: String(raw["created_by"]),
+    isFinished: Boolean(raw["is_finished"]),
+  };
+}
+
+function rawToPoll(raw: Record<string, unknown>): Poll {
+  return {
+    pollId: Number(raw["poll_id"]),
+    matchId: Number(raw["match_id"]),
+    creator: String(raw["creator"]),
+    question: String(raw["question"]),
+    category: Number(raw["category"]) as PollCategory,
+    lockTime: toDate(raw["lock_time"]),
+    yesPool: BigInt(String(raw["yes_pool"])),
+    noPool: BigInt(String(raw["no_pool"])),
+    yesCount: Number(raw["yes_count"]),
+    noCount: Number(raw["no_count"]),
+    status: Number(raw["status"]),
+    outcome:
+      raw["outcome"] != null ? Boolean(raw["outcome"]) : undefined,
+    resolutionTime:
+      raw["resolution_time"] != null
+        ? toDate(raw["resolution_time"])
+        : undefined,
+    createdAt: toDate(raw["created_at"]),
+  };
+}
+
+function rawToStake(raw: Record<string, unknown>): Stake {
+  return {
+    user: String(raw["user"]),
+    pollId: Number(raw["poll_id"]),
+    amount: BigInt(String(raw["amount"])),
+    side: Number(raw["side"]) as StakeSide,
+    claimed: Boolean(raw["claimed"]),
+    stakedAt: toDate(raw["staked_at"]),
+  };
+}
+
+function rawToPoolInfo(raw: Record<string, unknown>): PoolInfo {
+  return {
+    yesPool: BigInt(String(raw["yes_pool"])),
+    noPool: BigInt(String(raw["no_pool"])),
+    yesCount: Number(raw["yes_count"]),
+    noCount: Number(raw["no_count"]),
+  };
+}
+
+function rawToPlatformStats(raw: Record<string, unknown>): PlatformStats {
+  return {
+    totalValueLocked: BigInt(String(raw["total_value_locked"])),
+    totalPollsCreated: Number(raw["total_polls_created"]),
+    totalStakesPlaced: Number(raw["total_stakes_placed"]),
+    totalPayouts: BigInt(String(raw["total_payouts"])),
+    totalUsers: Number(raw["total_users"]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PredictionMarketClient
+// ---------------------------------------------------------------------------
+
+/** Options passed to state-mutating calls. */
+interface InvokeOptions {
+  wallet: StellarWallet;
+  /** Max fee in stroops (default 100 stroops = BASE_FEE). */
+  fee?: string;
+}
+
+/**
+ * Client for the `prediction-market` contract.
+ *
+ * @example
+ * ```ts
+ * const client = new PredictionMarketClient({
+ *   contractId: "CXXX...",
+ *   network: "testnet",
+ *   rpcUrl: "https://soroban-testnet.stellar.org",
+ * });
+ * const poll = await client.getPoll(1);
+ * ```
+ */
+export class PredictionMarketClient {
+  private readonly contract: Contract;
+  private readonly server: SorobanRpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(config: {
+    contractId: string;
+    network: NetworkName;
+    rpcUrl: string;
+  }) {
+    this.contract = new Contract(config.contractId);
+    this.server = new SorobanRpc.Server(config.rpcUrl, { allowHttp: true });
+    this.networkPassphrase = NETWORK_PASSPHRASE[config.network];
+  }
+
+  // -------------------------------------------------------------------------
+  // Private: simulation & submission helpers
+  // -------------------------------------------------------------------------
+
+  private async simulate<T>(
+    method: string,
+    ...args: xdr.ScVal[]
+  ): Promise<T> {
+    try {
+      const account = await this.server.getAccount(
+        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", // dummy for simulation
+      );
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const simResult = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(simResult)) {
+        throw parseSorobanError(new Error(simResult.error));
+      }
+      if (!SorobanRpc.Api.isSimulationSuccess(simResult)) {
+        throw new Error("Simulation failed");
+      }
+      const scVal = simResult.result?.retval;
+      return scValToNative(scVal!) as T;
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  private async invoke<T>(
+    method: string,
+    options: InvokeOptions,
+    ...args: xdr.ScVal[]
+  ): Promise<TransactionResult<T>> {
+    try {
+      const account = await this.server.getAccount(options.wallet.publicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: options.fee ?? BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const simResult = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(simResult)) {
+        throw parseSorobanError(new Error(simResult.error));
+      }
+
+      const prepared = SorobanRpc.assembleTransaction(tx, simResult).build();
+      const signedXdr = await options.wallet.signTransaction(
+        prepared.toXDR(),
+        this.networkPassphrase,
+      );
+
+      const submitted = await this.server.sendTransaction(
+        TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase),
+      );
+
+      if (submitted.status === "ERROR") {
+        throw new Error(`Transaction failed: ${submitted.errorResult}`);
+      }
+
+      // Poll for confirmation
+      let getResponse = await this.server.getTransaction(submitted.hash);
+      while (getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+        await new Promise((r) => setTimeout(r, 1000));
+        getResponse = await this.server.getTransaction(submitted.hash);
+      }
+
+      if (getResponse.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        throw new Error(`Transaction failed with status: ${getResponse.status}`);
+      }
+
+      const returnValue = getResponse.returnValue
+        ? (scValToNative(getResponse.returnValue) as T)
+        : (undefined as T);
+
+      return {
+        value: returnValue,
+        hash: submitted.hash,
+        ledger: getResponse.ledger,
+      };
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Matches
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches a single match by ID.
+   *
+   * @param matchId - The match ID.
+   */
+  async getMatch(matchId: number): Promise<Match> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_match",
+      nativeToScVal(matchId, { type: "u64" }),
+    );
+    return rawToMatch(raw);
+  }
+
+  /**
+   * Returns the total number of matches created.
+   */
+  async getMatchCount(): Promise<number> {
+    return this.simulate<number>("get_match_count");
+  }
+
+  /**
+   * Creates a new match (admin only).
+   */
+  async createMatch(
+    params: CreateMatchParams,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<number>> {
+    const result = await this.invoke<bigint>(
+      "create_match",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(params.homeTeam, { type: "string" }),
+      nativeToScVal(params.awayTeam, { type: "string" }),
+      nativeToScVal(params.league, { type: "string" }),
+      nativeToScVal(params.venue, { type: "string" }),
+      nativeToScVal(Math.floor(params.kickoffTime.getTime() / 1000), {
+        type: "u64",
+      }),
+    );
+    return { ...result, value: Number(result.value) };
+  }
+
+  /**
+   * Marks a match as finished, enabling the voting phase.
+   */
+  async finishMatch(
+    matchId: number,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<void>> {
+    return this.invoke<void>(
+      "finish_match",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(matchId, { type: "u64" }),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Polls
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches a single poll by ID.
+   *
+   * @param pollId - The poll ID.
+   */
+  async getPoll(pollId: number): Promise<Poll> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_poll",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return rawToPoll(raw);
+  }
+
+  /**
+   * Returns the IDs of all polls linked to a match.
+   *
+   * @param matchId - The match ID.
+   */
+  async getMatchPolls(matchId: number): Promise<number[]> {
+    const raw = await this.simulate<bigint[]>(
+      "get_match_polls",
+      nativeToScVal(matchId, { type: "u64" }),
+    );
+    return raw.map(Number);
+  }
+
+  /**
+   * Creates a new prediction poll (anyone can create).
+   *
+   * @param params  - Poll parameters.
+   * @param options - Wallet + fee options.
+   */
+  async createPoll(
+    params: CreatePollParams,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<number>> {
+    const result = await this.invoke<bigint>(
+      "create_poll",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(params.matchId, { type: "u64" }),
+      nativeToScVal(params.question, { type: "string" }),
+      nativeToScVal(params.category, { type: "u32" }),
+      nativeToScVal(Math.floor(params.lockTime.getTime() / 1000), {
+        type: "u64",
+      }),
+    );
+    return { ...result, value: Number(result.value) };
+  }
+
+  /**
+   * Cancels a poll (admin only). Enables emergency withdrawals.
+   */
+  async cancelPoll(
+    pollId: number,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<void>> {
+    return this.invoke<void>(
+      "cancel_poll",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Staking
+  // -------------------------------------------------------------------------
+
+  /**
+   * Places a stake on a poll.
+   *
+   * @param pollId  - Target poll.
+   * @param amount  - Amount in raw base units (bigint, 7 decimals).
+   * @param side    - StakeSide.Yes (0) or StakeSide.No (1).
+   * @param options - Wallet + fee options.
+   */
+  async stake(
+    pollId: number,
+    amount: bigint,
+    side: StakeSide,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<Stake>> {
+    const result = await this.invoke<Record<string, unknown>>(
+      "stake",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+      nativeToScVal(amount, { type: "i128" }),
+      nativeToScVal(side, { type: "u32" }),
+    );
+    return { ...result, value: rawToStake(result.value) };
+  }
+
+  /**
+   * Returns stake information for a user on a poll.
+   *
+   * @param pollId - The poll ID.
+   * @param user   - Stellar address of the staker.
+   */
+  async getStakeInfo(pollId: number, user: string): Promise<Stake> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_stake_info",
+      nativeToScVal(pollId, { type: "u64" }),
+      nativeToScVal(user, { type: "address" }),
+    );
+    return rawToStake(raw);
+  }
+
+  /**
+   * Returns all poll IDs the user has staked on.
+   */
+  async getUserStakes(user: string): Promise<number[]> {
+    const raw = await this.simulate<bigint[]>(
+      "get_user_stakes",
+      nativeToScVal(user, { type: "address" }),
+    );
+    return raw.map(Number);
+  }
+
+  /**
+   * Returns whether a user has staked on a given poll.
+   */
+  async hasUserStaked(pollId: number, user: string): Promise<boolean> {
+    return this.simulate<boolean>(
+      "has_user_staked",
+      nativeToScVal(pollId, { type: "u64" }),
+      nativeToScVal(user, { type: "address" }),
+    );
+  }
+
+  /**
+   * Returns the current pool info for a poll.
+   */
+  async getPoolInfo(pollId: number): Promise<PoolInfo> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_pool_info",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return rawToPoolInfo(raw);
+  }
+
+  /**
+   * Calculates potential winnings for a hypothetical stake (view only).
+   *
+   * @param pollId - The poll ID.
+   * @param side   - Which side to stake on.
+   * @param amount - Hypothetical stake amount (raw base units).
+   */
+  async calculatePotentialWinnings(
+    pollId: number,
+    side: StakeSide,
+    amount: bigint,
+  ): Promise<bigint> {
+    const pool = await this.getPoolInfo(pollId);
+    const { winnings } = calculatePotentialWinnings(
+      amount,
+      side === 0 ? "yes" : "no",
+      pool.yesPool,
+      pool.noPool,
+    );
+    return winnings;
+  }
+
+  // -------------------------------------------------------------------------
+  // Claims
+  // -------------------------------------------------------------------------
+
+  /**
+   * Claims winnings for a resolved poll (winning stakers only).
+   */
+  async claimWinnings(
+    pollId: number,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<bigint>> {
+    const result = await this.invoke<bigint>(
+      "claim_winnings",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return result;
+  }
+
+  /**
+   * Emergency withdrawal for cancelled / disputed polls (after 7-day timeout).
+   */
+  async emergencyWithdraw(
+    pollId: number,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<bigint>> {
+    const result = await this.invoke<bigint>(
+      "emergency_withdraw",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Platform stats
+  // -------------------------------------------------------------------------
+
+  /**
+   * Returns aggregate platform statistics.
+   */
+  async getPlatformStats(): Promise<PlatformStats> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_platform_stats",
+    );
+    return rawToPlatformStats(raw);
+  }
+
+  /**
+   * Returns the token address used by the protocol.
+   */
+  async getTokenAddress(): Promise<string> {
+    return this.simulate<string>("get_token_address");
+  }
+
+  /**
+   * Returns the treasury contract address.
+   */
+  async getTreasuryAddress(): Promise<string> {
+    return this.simulate<string>("get_treasury_address");
+  }
+
+  /**
+   * Returns the platform fee in basis points.
+   */
+  async getPlatformFeeBps(): Promise<number> {
+    return this.simulate<number>("get_platform_fee_bps");
+  }
+
+  /**
+   * Returns the current contract balance.
+   */
+  async getContractBalance(): Promise<bigint> {
+    return this.simulate<bigint>("get_contract_balance");
+  }
+
+  /**
+   * Returns whether the contract is paused.
+   */
+  async isPaused(): Promise<boolean> {
+    return this.simulate<boolean>("is_paused");
+  }
+}

--- a/predictx-sdk/src/contracts/treasury.ts
+++ b/predictx-sdk/src/contracts/treasury.ts
@@ -1,0 +1,162 @@
+/**
+ * PredictX SDK — Treasury contract client.
+ */
+
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  xdr,
+  scValToNative,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+import type {
+  StellarWallet,
+  TransactionResult,
+  NetworkName,
+} from "../types/index";
+import { parseSorobanError } from "../errors";
+
+const NETWORK_PASSPHRASE: Record<NetworkName, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+  standalone: Networks.STANDALONE,
+};
+
+interface InvokeOptions {
+  wallet: StellarWallet;
+  fee?: string;
+}
+
+/**
+ * Client for the `treasury` contract.
+ */
+export class TreasuryClient {
+  private readonly contract: Contract;
+  private readonly server: SorobanRpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(config: {
+    contractId: string;
+    network: NetworkName;
+    rpcUrl: string;
+  }) {
+    this.contract = new Contract(config.contractId);
+    this.server = new SorobanRpc.Server(config.rpcUrl, { allowHttp: true });
+    this.networkPassphrase = NETWORK_PASSPHRASE[config.network];
+  }
+
+  private async simulate<T>(method: string, ...args: xdr.ScVal[]): Promise<T> {
+    try {
+      const account = await this.server.getAccount(
+        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      );
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+      return scValToNative(sim.result!.retval) as T;
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  private async invoke<T>(
+    method: string,
+    options: InvokeOptions,
+    ...args: xdr.ScVal[]
+  ): Promise<TransactionResult<T>> {
+    try {
+      const account = await this.server.getAccount(options.wallet.publicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: options.fee ?? BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+
+      const prepared = SorobanRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await options.wallet.signTransaction(
+        prepared.toXDR(),
+        this.networkPassphrase,
+      );
+      const submitted = await this.server.sendTransaction(
+        TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase),
+      );
+
+      if (submitted.status === "ERROR") {
+        throw new Error(`Transaction failed: ${submitted.errorResult}`);
+      }
+
+      let getResponse = await this.server.getTransaction(submitted.hash);
+      while (
+        getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND
+      ) {
+        await new Promise((r) => setTimeout(r, 1000));
+        getResponse = await this.server.getTransaction(submitted.hash);
+      }
+
+      const returnValue = getResponse.returnValue
+        ? (scValToNative(getResponse.returnValue) as T)
+        : (undefined as T);
+
+      return {
+        value: returnValue,
+        hash: submitted.hash,
+        ledger: getResponse.ledger,
+      };
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  /**
+   * Returns the balance recorded in treasury for a given address.
+   *
+   * @param who - Stellar address to query.
+   */
+  async getBalance(who: string): Promise<bigint> {
+    return this.simulate<bigint>(
+      "balance",
+      nativeToScVal(who, { type: "address" }),
+    );
+  }
+
+  /**
+   * Records a deposit into the treasury (called by protocol contracts).
+   *
+   * @param from    - Depositor address.
+   * @param amount  - Amount in base units.
+   * @param options - Wallet + fee options.
+   */
+  async deposit(
+    from: string,
+    amount: bigint,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<bigint>> {
+    return this.invoke<bigint>(
+      "deposit",
+      options,
+      nativeToScVal(from, { type: "address" }),
+      nativeToScVal(amount, { type: "i128" }),
+    );
+  }
+}

--- a/predictx-sdk/src/contracts/voting-oracle.ts
+++ b/predictx-sdk/src/contracts/voting-oracle.ts
@@ -1,0 +1,223 @@
+/**
+ * PredictX SDK — VotingOracle contract client.
+ */
+
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  xdr,
+  scValToNative,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+import type {
+  VoteTally,
+  VoteChoice,
+  StellarWallet,
+  TransactionResult,
+  NetworkName,
+} from "../types/index";
+import { parseSorobanError } from "../errors";
+
+const NETWORK_PASSPHRASE: Record<NetworkName, string> = {
+  mainnet: Networks.PUBLIC,
+  testnet: Networks.TESTNET,
+  futurenet: Networks.FUTURENET,
+  standalone: Networks.STANDALONE,
+};
+
+function toDate(unixSecs: unknown): Date {
+  return new Date(Number(unixSecs) * 1000);
+}
+
+function rawToVoteTally(raw: Record<string, unknown>): VoteTally {
+  return {
+    pollId: Number(raw["poll_id"]),
+    yesVotes: Number(raw["yes_votes"]),
+    noVotes: Number(raw["no_votes"]),
+    unclearVotes: Number(raw["unclear_votes"]),
+    totalVoters: Number(raw["total_voters"]),
+    votingEndTime: toDate(raw["voting_end_time"]),
+    rewardPool: BigInt(String(raw["reward_pool"])),
+  };
+}
+
+interface InvokeOptions {
+  wallet: StellarWallet;
+  fee?: string;
+}
+
+/**
+ * Client for the `voting-oracle` contract.
+ */
+export class VotingOracleClient {
+  private readonly contract: Contract;
+  private readonly server: SorobanRpc.Server;
+  private readonly networkPassphrase: string;
+
+  constructor(config: {
+    contractId: string;
+    network: NetworkName;
+    rpcUrl: string;
+  }) {
+    this.contract = new Contract(config.contractId);
+    this.server = new SorobanRpc.Server(config.rpcUrl, { allowHttp: true });
+    this.networkPassphrase = NETWORK_PASSPHRASE[config.network];
+  }
+
+  private async simulate<T>(method: string, ...args: xdr.ScVal[]): Promise<T> {
+    try {
+      const account = await this.server.getAccount(
+        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      );
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+      return scValToNative(sim.result!.retval) as T;
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  private async invoke<T>(
+    method: string,
+    options: InvokeOptions,
+    ...args: xdr.ScVal[]
+  ): Promise<TransactionResult<T>> {
+    try {
+      const account = await this.server.getAccount(options.wallet.publicKey);
+      const tx = new TransactionBuilder(account, {
+        fee: options.fee ?? BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(this.contract.call(method, ...args))
+        .setTimeout(30)
+        .build();
+
+      const sim = await this.server.simulateTransaction(tx);
+      if (SorobanRpc.Api.isSimulationError(sim)) {
+        throw parseSorobanError(new Error(sim.error));
+      }
+
+      const prepared = SorobanRpc.assembleTransaction(tx, sim).build();
+      const signedXdr = await options.wallet.signTransaction(
+        prepared.toXDR(),
+        this.networkPassphrase,
+      );
+      const submitted = await this.server.sendTransaction(
+        TransactionBuilder.fromXDR(signedXdr, this.networkPassphrase),
+      );
+
+      if (submitted.status === "ERROR") {
+        throw new Error(`Transaction failed: ${submitted.errorResult}`);
+      }
+
+      let getResponse = await this.server.getTransaction(submitted.hash);
+      while (
+        getResponse.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND
+      ) {
+        await new Promise((r) => setTimeout(r, 1000));
+        getResponse = await this.server.getTransaction(submitted.hash);
+      }
+
+      if (
+        getResponse.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS
+      ) {
+        throw new Error(`Transaction failed: ${getResponse.status}`);
+      }
+
+      const returnValue = getResponse.returnValue
+        ? (scValToNative(getResponse.returnValue) as T)
+        : (undefined as T);
+
+      return {
+        value: returnValue,
+        hash: submitted.hash,
+        ledger: getResponse.ledger,
+      };
+    } catch (err) {
+      throw parseSorobanError(err);
+    }
+  }
+
+  /**
+   * Casts a vote on a locked poll.
+   *
+   * @param pollId - The poll to vote on.
+   * @param choice - VoteChoice.Yes, .No, or .Unclear.
+   * @param options - Wallet + fee options.
+   */
+  async castVote(
+    pollId: number,
+    choice: VoteChoice,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<VoteTally>> {
+    const result = await this.invoke<Record<string, unknown>>(
+      "cast_vote",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+      nativeToScVal(choice, { type: "u32" }),
+    );
+    return { ...result, value: rawToVoteTally(result.value) };
+  }
+
+  /**
+   * Returns the current vote tally for a poll.
+   */
+  async getVoteTally(pollId: number): Promise<VoteTally> {
+    const raw = await this.simulate<Record<string, unknown>>(
+      "get_vote_tally",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return rawToVoteTally(raw);
+  }
+
+  /**
+   * Returns the oracle status of a poll.
+   */
+  async getPollStatus(pollId: number): Promise<number> {
+    return this.simulate<number>(
+      "get_poll_status",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+  }
+
+  /**
+   * Returns the timestamp of the last poll-status update.
+   */
+  async getPollStatusUpdatedAt(pollId: number): Promise<Date> {
+    const ts = await this.simulate<number>(
+      "get_poll_status_updated_at",
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+    return new Date(ts * 1000);
+  }
+
+  /**
+   * Claims the voting reward for a correctly-voted resolved poll.
+   */
+  async claimVotingReward(
+    pollId: number,
+    options: InvokeOptions,
+  ): Promise<TransactionResult<bigint>> {
+    return this.invoke<bigint>(
+      "claim_voting_reward",
+      options,
+      nativeToScVal(options.wallet.publicKey, { type: "address" }),
+      nativeToScVal(pollId, { type: "u64" }),
+    );
+  }
+}

--- a/predictx-sdk/src/errors.ts
+++ b/predictx-sdk/src/errors.ts
@@ -1,0 +1,116 @@
+/**
+ * PredictX SDK — Error mapping layer.
+ *
+ * Maps on-chain `PredictXError` u32 codes to typed TypeScript errors so
+ * callers never need to decode raw contract error codes.
+ */
+
+/** Numeric error codes emitted by the PredictX smart contracts. */
+export enum PredictXErrorCode {
+  NotInitialized = 1,
+  AlreadyInitialized = 2,
+  Unauthorized = 3,
+  PollNotFound = 4,
+  PollNotActive = 5,
+  PollLocked = 6,
+  PollNotLocked = 7,
+  PollAlreadyResolved = 8,
+  InsufficientBalance = 9,
+  StakeAmountZero = 10,
+  AlreadyStaked = 11,
+  NotStaker = 12,
+  AlreadyClaimed = 13,
+  NotOnWinningSide = 14,
+  VotingNotOpen = 15,
+  AlreadyVoted = 16,
+  VoterIsStaker = 17,
+  VotingWindowExpired = 18,
+  DisputeAlreadyOpen = 19,
+  DisputeFeeRequired = 20,
+  InvalidPollCategory = 21,
+  InvalidLockTime = 22,
+  MatchNotFound = 23,
+  MatchAlreadyStarted = 24,
+  PollQuestionTooLong = 25,
+  MaxPollsPerMatchReached = 26,
+  InvalidOutcome = 27,
+  ConsensusNotReached = 28,
+  AdminAlreadyRegistered = 29,
+  InsufficientAdminApprovals = 30,
+  EmergencyWithdrawNotAllowed = 31,
+  TransferFailed = 32,
+  ContractPaused = 33,
+  StakeBelowMinimum = 34,
+}
+
+const ERROR_MESSAGES: Record<PredictXErrorCode, string> = {
+  [PredictXErrorCode.NotInitialized]: "Contract is not initialized",
+  [PredictXErrorCode.AlreadyInitialized]: "Contract is already initialized",
+  [PredictXErrorCode.Unauthorized]: "Unauthorized: admin privileges required",
+  [PredictXErrorCode.PollNotFound]: "Poll not found",
+  [PredictXErrorCode.PollNotActive]: "Poll is no longer active",
+  [PredictXErrorCode.PollLocked]: "Poll is locked — no more stakes accepted",
+  [PredictXErrorCode.PollNotLocked]: "Poll has not been locked yet",
+  [PredictXErrorCode.PollAlreadyResolved]: "Poll has already been resolved",
+  [PredictXErrorCode.InsufficientBalance]: "Insufficient token balance",
+  [PredictXErrorCode.StakeAmountZero]: "Stake amount must be greater than zero",
+  [PredictXErrorCode.AlreadyStaked]: "You have already staked on this poll",
+  [PredictXErrorCode.NotStaker]: "You have not staked on this poll",
+  [PredictXErrorCode.AlreadyClaimed]: "Winnings have already been claimed",
+  [PredictXErrorCode.NotOnWinningSide]: "Your stake was on the losing side",
+  [PredictXErrorCode.VotingNotOpen]: "Voting is not currently open for this poll",
+  [PredictXErrorCode.AlreadyVoted]: "You have already voted on this poll",
+  [PredictXErrorCode.VoterIsStaker]: "Stakers cannot vote on their own poll",
+  [PredictXErrorCode.VotingWindowExpired]: "The voting window has expired",
+  [PredictXErrorCode.DisputeAlreadyOpen]: "A dispute is already open for this poll",
+  [PredictXErrorCode.DisputeFeeRequired]: "A dispute fee is required",
+  [PredictXErrorCode.InvalidPollCategory]: "Invalid poll category",
+  [PredictXErrorCode.InvalidLockTime]: "Lock time must be in the future",
+  [PredictXErrorCode.MatchNotFound]: "Match not found",
+  [PredictXErrorCode.MatchAlreadyStarted]: "Match has already started",
+  [PredictXErrorCode.PollQuestionTooLong]: `Poll question exceeds maximum length`,
+  [PredictXErrorCode.MaxPollsPerMatchReached]: "Maximum polls per match reached",
+  [PredictXErrorCode.InvalidOutcome]: "Invalid poll outcome",
+  [PredictXErrorCode.ConsensusNotReached]: "Voting consensus was not reached",
+  [PredictXErrorCode.AdminAlreadyRegistered]: "Admin is already registered",
+  [PredictXErrorCode.InsufficientAdminApprovals]: "Insufficient admin approvals",
+  [PredictXErrorCode.EmergencyWithdrawNotAllowed]: "Emergency withdrawal is not allowed yet",
+  [PredictXErrorCode.TransferFailed]: "Token transfer failed",
+  [PredictXErrorCode.ContractPaused]: "Contract is currently paused",
+  [PredictXErrorCode.StakeBelowMinimum]: "Stake amount is below the minimum required",
+};
+
+/** Typed error thrown by PredictX SDK operations. */
+export class PredictXError extends Error {
+  constructor(
+    public readonly code: PredictXErrorCode,
+    public readonly context?: string,
+  ) {
+    const base = ERROR_MESSAGES[code] ?? `Contract error code ${code}`;
+    super(context ? `${base}: ${context}` : base);
+    this.name = "PredictXError";
+  }
+}
+
+/**
+ * Attempts to parse a raw Soroban contract error and returns a typed
+ * `PredictXError`.  Falls back to a generic `Error` for unknown codes.
+ *
+ * @param raw - The raw error thrown by the Stellar SDK.
+ */
+export function parseSorobanError(raw: unknown): Error {
+  if (raw instanceof PredictXError) return raw;
+
+  const message = raw instanceof Error ? raw.message : String(raw);
+
+  // Soroban error codes surface as "Error(Contract, #N)" in the message
+  const match = message.match(/Error\(Contract,\s*#(\d+)\)/);
+  if (match) {
+    const code = parseInt(match[1], 10) as PredictXErrorCode;
+    if (code in PredictXErrorCode) {
+      return new PredictXError(code);
+    }
+  }
+
+  return raw instanceof Error ? raw : new Error(message);
+}

--- a/predictx-sdk/src/events/parser.ts
+++ b/predictx-sdk/src/events/parser.ts
@@ -1,0 +1,131 @@
+/**
+ * PredictX SDK — Soroban event parser.
+ *
+ * Transforms raw `SorobanEvent` objects returned by the RPC API into
+ * strongly-typed `PredictXEvent` objects.
+ */
+
+import type {
+  PredictXEvent,
+  PollCategory,
+  StakeSide,
+} from "../types/index";
+
+/** Minimal interface that mirrors the Stellar SDK's SorobanEvent shape. */
+interface RawSorobanEvent {
+  type: string;
+  /** Array of ScVal topics (encoded as objects with `value` properties). */
+  topic: Array<{ type: string; value: unknown }>;
+  /** Event data as a ScVal. */
+  value: { type: string; value: unknown };
+}
+
+/**
+ * Parses a raw Soroban contract event into a typed PredictXEvent.
+ *
+ * @param rawEvent - Raw event from the Stellar SDK / RPC streaming.
+ * @returns Typed PredictXEvent, or `null` if the event is unrecognised.
+ */
+export function parseEvent(rawEvent: RawSorobanEvent): PredictXEvent | null {
+  try {
+    const topics = rawEvent.topic.map((t) => String(t.value));
+    if (topics.length < 2) return null;
+
+    const [category, action] = topics;
+    const key = `${category}:${action}`;
+
+    switch (key) {
+      case "poll:created":
+        return parsePollCreatedEvent(rawEvent);
+      case "poll:cancelled":
+        return parsePollCancelledEvent(rawEvent);
+      case "stake:placed":
+        return parseStakePlacedEvent(rawEvent);
+      case "stake:emergency_withdrawal":
+        return parseEmergencyWithdrawalEvent(rawEvent);
+      case "match:created":
+        return parseMatchCreatedEvent(rawEvent);
+      case "contract:paused":
+        return parseContractPausedEvent(rawEvent);
+      case "contract:unpaused":
+        return parseContractUnpausedEvent(rawEvent);
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual event parsers
+// ---------------------------------------------------------------------------
+
+function parsePollCreatedEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "poll:created",
+    pollId: Number(data["poll_id"]),
+    matchId: Number(data["match_id"]),
+    creator: String(data["creator"]),
+    question: String(data["question"]),
+    category: Number(data["category"]) as PollCategory,
+    lockTime: new Date(Number(data["lock_time"]) * 1000),
+  };
+}
+
+function parsePollCancelledEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "poll:cancelled",
+    pollId: Number(data["poll_id"]),
+    admin: String(data["admin"]),
+  };
+}
+
+function parseStakePlacedEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "stake:placed",
+    pollId: Number(data["poll_id"]),
+    staker: String(data["staker"]),
+    amount: BigInt(String(data["amount"])),
+    side: Number(data["side"]) as StakeSide,
+  };
+}
+
+function parseEmergencyWithdrawalEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "stake:emergency_withdrawal",
+    pollId: Number(data["poll_id"]),
+    user: String(data["user"]),
+    amount: BigInt(String(data["amount"])),
+  };
+}
+
+function parseMatchCreatedEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "match:created",
+    matchId: Number(data["match_id"]),
+    homeTeam: String(data["home_team"]),
+    awayTeam: String(data["away_team"]),
+  };
+}
+
+function parseContractPausedEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "contract:paused",
+    admin: String(data["admin"]),
+  };
+}
+
+function parseContractUnpausedEvent(ev: RawSorobanEvent): PredictXEvent {
+  const data = ev.value.value as Record<string, unknown>;
+  return {
+    type: "contract:unpaused",
+    admin: String(data["admin"]),
+  };
+}

--- a/predictx-sdk/src/events/types.ts
+++ b/predictx-sdk/src/events/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-export all event types from the main types module so callers can
+ * import from either `@predictx/sdk` or `@predictx/sdk/events`.
+ */
+export type {
+  PredictXEvent,
+  PollCreatedEvent,
+  PollCancelledEvent,
+  StakePlacedEvent,
+  EmergencyWithdrawalEvent,
+  MatchCreatedEvent,
+  ContractPausedEvent,
+  ContractUnpausedEvent,
+  EventCallback,
+  Unsubscribe,
+} from "../types/index";

--- a/predictx-sdk/src/index.ts
+++ b/predictx-sdk/src/index.ts
@@ -1,0 +1,114 @@
+/**
+ * @predictx/sdk — TypeScript SDK for the PredictX Soroban prediction market.
+ *
+ * ## Quick Start
+ *
+ * ```ts
+ * import {
+ *   PredictXClient,
+ *   PollStatus,
+ *   StakeSide,
+ *   VoteChoice,
+ *   formatTokenAmount,
+ *   calculatePotentialWinnings,
+ * } from "@predictx/sdk";
+ *
+ * const client = new PredictXClient({
+ *   network: "testnet",
+ *   contractIds: {
+ *     predictionMarket: "CXXX...",
+ *     votingOracle:     "CYYY...",
+ *     treasury:         "CZZZ...",
+ *     pollFactory:      "CWWW...",
+ *   },
+ * });
+ *
+ * // Connect Freighter (or any StellarWallet implementation)
+ * await client.connect(freighterWallet);
+ *
+ * // Browse polls
+ * const polls = await client.getTrendingPolls(10);
+ *
+ * // Stake
+ * const result = await client.stake(pollId, 100_000_000n, StakeSide.Yes);
+ * ```
+ */
+
+// Main client
+export { PredictXClient } from "./client";
+
+// Contract-level clients (for advanced use)
+export { PredictionMarketClient } from "./contracts/prediction-market";
+export { VotingOracleClient } from "./contracts/voting-oracle";
+export { TreasuryClient } from "./contracts/treasury";
+export { PollFactoryClient } from "./contracts/poll-factory";
+
+// Types
+export type {
+  Match,
+  Poll,
+  Stake,
+  PoolInfo,
+  VoteTally,
+  Dispute,
+  PlatformStats,
+  UserStats,
+  PredictionHistoryEntry,
+  PredictXConfig,
+  StellarWallet,
+  TransactionResult,
+  CreateMatchParams,
+  CreatePollParams,
+  EventCallback,
+  Unsubscribe,
+  PredictXEvent,
+  PollCreatedEvent,
+  PollCancelledEvent,
+  StakePlacedEvent,
+  EmergencyWithdrawalEvent,
+  MatchCreatedEvent,
+  ContractPausedEvent,
+  ContractUnpausedEvent,
+  NetworkName,
+} from "./types/index";
+
+export { PollStatus, PollCategory, StakeSide, VoteChoice } from "./types/index";
+
+// Errors
+export { PredictXError, PredictXErrorCode, parseSorobanError } from "./errors";
+
+// Event utilities
+export { parseEvent } from "./events/parser";
+
+// Calculation utilities
+export {
+  calculatePotentialWinnings,
+  calculateClaimableWinnings,
+  calculatePlatformFee,
+  calculateVoterRewardPool,
+  formatTokenAmount,
+  parseTokenAmount,
+} from "./utils/calculations";
+
+// Formatting utilities
+export {
+  truncateAddress,
+  formatDate,
+  formatCountdown,
+  formatPercent,
+} from "./utils/formatting";
+
+// Constants
+export {
+  PLATFORM_FEE_BPS,
+  VOTER_REWARD_BPS,
+  BPS_DENOMINATOR,
+  VOTING_WINDOW_SECS,
+  DISPUTE_WINDOW_SECS,
+  AUTO_RESOLVE_THRESHOLD_BPS,
+  ADMIN_REVIEW_THRESHOLD_BPS,
+  MAX_QUESTION_LENGTH,
+  MAX_POLLS_PER_MATCH,
+  EMERGENCY_TIMEOUT_SECS,
+  MIN_STAKE_AMOUNT,
+} from "./utils/constants";

--- a/predictx-sdk/src/types/index.ts
+++ b/predictx-sdk/src/types/index.ts
@@ -1,0 +1,302 @@
+/**
+ * PredictX SDK — Shared Type Definitions
+ *
+ * All types mirror the on-chain contract structs exactly:
+ *   - `i128` fields → `bigint`
+ *   - `u32` / `u64` numeric fields → `number`
+ *   - `Address` → `string` (Stellar account/contract ID)
+ *   - `u64` Unix timestamps → `Date`
+ *   - `Option<T>` → `T | undefined`
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/** The lifecycle status of a prediction poll. */
+export enum PollStatus {
+  /** Accepting stakes. */
+  Active = 0,
+  /** Past lock time — no more stakes. */
+  Locked = 1,
+  /** Community voting in progress. */
+  Voting = 2,
+  /** Vote consensus 60–85%, needs admin review. */
+  AdminReview = 3,
+  /** Under dispute review. */
+  Disputed = 4,
+  /** Outcome determined — claims open. */
+  Resolved = 5,
+  /** Emergency cancelled — refunds available. */
+  Cancelled = 6,
+}
+
+/** Poll question category. */
+export enum PollCategory {
+  PlayerEvent = 0,
+  TeamEvent = 1,
+  ScorePrediction = 2,
+  Other = 3,
+}
+
+/** Which side of a poll a user staked on. */
+export enum StakeSide {
+  Yes = 0,
+  No = 1,
+}
+
+/** Oracle / community vote choice. */
+export enum VoteChoice {
+  Yes = 0,
+  No = 1,
+  /** For genuinely ambiguous outcomes. */
+  Unclear = 2,
+}
+
+// ---------------------------------------------------------------------------
+// Core structs
+// ---------------------------------------------------------------------------
+
+/** A football match that polls can be created against. */
+export interface Match {
+  matchId: number;
+  homeTeam: string;
+  awayTeam: string;
+  league: string;
+  venue: string;
+  kickoffTime: Date;
+  createdBy: string;
+  isFinished: boolean;
+}
+
+/** A prediction poll. */
+export interface Poll {
+  pollId: number;
+  matchId: number;
+  creator: string;
+  question: string;
+  category: PollCategory;
+  lockTime: Date;
+  /** Total tokens staked on the YES side (7-decimal precision). */
+  yesPool: bigint;
+  /** Total tokens staked on the NO side (7-decimal precision). */
+  noPool: bigint;
+  /** Number of individual YES stakers. */
+  yesCount: number;
+  /** Number of individual NO stakers. */
+  noCount: number;
+  status: PollStatus;
+  /** Outcome once resolved; undefined while poll is pending. */
+  outcome?: boolean;
+  resolutionTime?: Date;
+  createdAt: Date;
+}
+
+/** A user's stake on a poll. */
+export interface Stake {
+  user: string;
+  pollId: number;
+  amount: bigint;
+  side: StakeSide;
+  claimed: boolean;
+  stakedAt: Date;
+  /** Calculated client-side — not stored on-chain. */
+  potentialWinnings?: bigint;
+  /** Return-on-investment percentage (client-side). */
+  roi?: number;
+}
+
+/** Snapshot of pool balances for a poll. */
+export interface PoolInfo {
+  yesPool: bigint;
+  noPool: bigint;
+  yesCount: number;
+  noCount: number;
+}
+
+/** Community vote tally for a poll. */
+export interface VoteTally {
+  pollId: number;
+  yesVotes: number;
+  noVotes: number;
+  unclearVotes: number;
+  totalVoters: number;
+  votingEndTime: Date;
+  /** 0.5–1% of pool reserved for voter incentives. */
+  rewardPool: bigint;
+}
+
+/** A dispute raised against a poll outcome. */
+export interface Dispute {
+  pollId: number;
+  initiator: string;
+  evidenceHash: string;
+  disputeFee: bigint;
+  adminApprovals: number;
+  requiredApprovals: number;
+  resolved: boolean;
+  initiatedAt: Date;
+}
+
+/** Aggregate platform statistics. */
+export interface PlatformStats {
+  totalValueLocked: bigint;
+  totalPollsCreated: number;
+  totalStakesPlaced: number;
+  totalPayouts: bigint;
+  totalUsers: number;
+}
+
+/** Per-user statistics. */
+export interface UserStats {
+  totalStaked: bigint;
+  totalWon: bigint;
+  totalLost: bigint;
+  pollsParticipated: number;
+  pollsWon: number;
+  pollsLost: number;
+  votesCast: number;
+  votingRewardsEarned: bigint;
+}
+
+/** A single entry in a user's prediction history. */
+export interface PredictionHistoryEntry {
+  pollId: number;
+  question: string;
+  side: StakeSide;
+  amount: bigint;
+  outcome?: boolean;
+  winnings?: bigint;
+  status: PollStatus;
+  stakedAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// SDK configuration & connection
+// ---------------------------------------------------------------------------
+
+/** Supported Stellar networks. */
+export type NetworkName = "mainnet" | "testnet" | "futurenet" | "standalone";
+
+/** SDK initialisation config. */
+export interface PredictXConfig {
+  network: NetworkName;
+  /** RPC URL — defaults to Horizon/Soroban public endpoints. */
+  rpcUrl?: string;
+  /** Contract IDs — required for all operations. */
+  contractIds: {
+    predictionMarket: string;
+    votingOracle: string;
+    treasury: string;
+    pollFactory: string;
+  };
+  /** XLM token contract address used by the protocol. */
+  tokenAddress?: string;
+}
+
+/** A minimal wallet interface that the SDK accepts. */
+export interface StellarWallet {
+  /** Public key of the connected account. */
+  publicKey: string;
+  /** Sign a transaction XDR and return the signed XDR. */
+  signTransaction(xdr: string, network?: string): Promise<string>;
+}
+
+// ---------------------------------------------------------------------------
+// SDK operation results
+// ---------------------------------------------------------------------------
+
+/** Wraps the outcome of any state-mutating on-chain call. */
+export interface TransactionResult<T> {
+  /** Contract return value (decoded). */
+  value: T;
+  /** Transaction hash. */
+  hash: string;
+  /** Ledger sequence number. */
+  ledger: number;
+}
+
+/** Parameters for creating a new match. */
+export interface CreateMatchParams {
+  homeTeam: string;
+  awayTeam: string;
+  league: string;
+  venue: string;
+  kickoffTime: Date;
+}
+
+/** Parameters for creating a new poll. */
+export interface CreatePollParams {
+  matchId: number;
+  question: string;
+  category: PollCategory;
+  lockTime: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/** Callback type for real-time event subscriptions. */
+export type EventCallback = (event: PredictXEvent) => void;
+
+/** Unsubscribe function returned by `subscribeToEvents`. */
+export type Unsubscribe = () => void;
+
+/** Discriminated union of all PredictX contract events. */
+export type PredictXEvent =
+  | PollCreatedEvent
+  | PollCancelledEvent
+  | StakePlacedEvent
+  | EmergencyWithdrawalEvent
+  | MatchCreatedEvent
+  | ContractPausedEvent
+  | ContractUnpausedEvent;
+
+export interface PollCreatedEvent {
+  type: "poll:created";
+  pollId: number;
+  matchId: number;
+  creator: string;
+  question: string;
+  category: PollCategory;
+  lockTime: Date;
+}
+
+export interface PollCancelledEvent {
+  type: "poll:cancelled";
+  pollId: number;
+  admin: string;
+}
+
+export interface StakePlacedEvent {
+  type: "stake:placed";
+  pollId: number;
+  staker: string;
+  amount: bigint;
+  side: StakeSide;
+}
+
+export interface EmergencyWithdrawalEvent {
+  type: "stake:emergency_withdrawal";
+  pollId: number;
+  user: string;
+  amount: bigint;
+}
+
+export interface MatchCreatedEvent {
+  type: "match:created";
+  matchId: number;
+  homeTeam: string;
+  awayTeam: string;
+}
+
+export interface ContractPausedEvent {
+  type: "contract:paused";
+  admin: string;
+}
+
+export interface ContractUnpausedEvent {
+  type: "contract:unpaused";
+  admin: string;
+}

--- a/predictx-sdk/src/utils/calculations.ts
+++ b/predictx-sdk/src/utils/calculations.ts
@@ -1,0 +1,153 @@
+/**
+ * PredictX — Client-side calculation utilities.
+ *
+ * These functions replicate the on-chain maths so the UI can show
+ * preview values before a transaction is submitted.  All amounts are
+ * in the token's raw base units (7-decimal precision, like XLM stroops).
+ */
+
+import { PLATFORM_FEE_BPS, VOTER_REWARD_BPS, BPS_DENOMINATOR } from "./constants";
+
+// ---------------------------------------------------------------------------
+// Core winnings preview
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates the potential winnings if `yourStake` wins.
+ *
+ * Formula (mirrors `calculate_potential_winnings` in the contract):
+ *   totalPool        = yesPool + noPool + yourStake
+ *   distributable    = totalPool × (1 − (feeBps + voterBps) / 10_000)
+ *   winnings         = yourStake × distributable / (yourSidePool + yourStake)
+ *
+ * @param yourStake     - Amount being staked (base units, bigint).
+ * @param yourSide      - "yes" or "no".
+ * @param currentYesPool - Current YES pool before this stake.
+ * @param currentNoPool  - Current NO pool before this stake.
+ * @param feeBps        - Platform fee in basis points (default 500 = 5%).
+ * @param voterRewardBps - Voter reward reservation in bps (default 100 = 1%).
+ * @returns Object with `winnings`, `profit`, and `roi` (percentage as number).
+ */
+export function calculatePotentialWinnings(
+  yourStake: bigint,
+  yourSide: "yes" | "no",
+  currentYesPool: bigint,
+  currentNoPool: bigint,
+  feeBps: number = PLATFORM_FEE_BPS,
+  voterRewardBps: number = VOTER_REWARD_BPS,
+): { winnings: bigint; profit: bigint; roi: number } {
+  if (yourStake <= 0n) {
+    return { winnings: 0n, profit: 0n, roi: 0 };
+  }
+
+  const yourSidePool =
+    yourSide === "yes" ? currentYesPool : currentNoPool;
+
+  const totalDeductions = BigInt(feeBps + voterRewardBps);
+  const totalPool = currentYesPool + currentNoPool + yourStake;
+  const distributable =
+    totalPool - (totalPool * totalDeductions) / BigInt(BPS_DENOMINATOR);
+  const poolAfterStake = yourSidePool + yourStake;
+
+  const winnings = (yourStake * distributable) / poolAfterStake;
+  const profit = winnings - yourStake;
+  const roi =
+    yourStake > 0n
+      ? Number((profit * 10_000n) / yourStake) / 100
+      : 0;
+
+  return { winnings, profit, roi };
+}
+
+// ---------------------------------------------------------------------------
+// Claim winnings (post-resolution)
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculates the claimable winnings for a winning stake after resolution.
+ *
+ * @param stakeAmount     - The user's original stake.
+ * @param stakePool       - Total tokens staked on the winning side.
+ * @param totalPool       - Total tokens across both sides.
+ * @param feeBps          - Platform fee in basis points.
+ * @param voterRewardBps  - Voter reward in basis points.
+ * @returns Claimable amount in base units.
+ */
+export function calculateClaimableWinnings(
+  stakeAmount: bigint,
+  stakePool: bigint,
+  totalPool: bigint,
+  feeBps: number = PLATFORM_FEE_BPS,
+  voterRewardBps: number = VOTER_REWARD_BPS,
+): bigint {
+  if (stakePool === 0n) return 0n;
+
+  const totalDeductions = BigInt(feeBps + voterRewardBps);
+  const distributable =
+    totalPool - (totalPool * totalDeductions) / BigInt(BPS_DENOMINATOR);
+
+  return (stakeAmount * distributable) / stakePool;
+}
+
+// ---------------------------------------------------------------------------
+// Platform fee & voter reward breakdowns
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the platform fee that would be taken from a given pool total.
+ *
+ * @param totalPool - Total pool amount.
+ * @param feeBps    - Fee in basis points (default 500).
+ */
+export function calculatePlatformFee(
+  totalPool: bigint,
+  feeBps: number = PLATFORM_FEE_BPS,
+): bigint {
+  return (totalPool * BigInt(feeBps)) / BigInt(BPS_DENOMINATOR);
+}
+
+/**
+ * Returns the voter reward pool carved out from a given pool total.
+ *
+ * @param totalPool      - Total pool amount.
+ * @param voterRewardBps - Voter reward in basis points (default 100).
+ */
+export function calculateVoterRewardPool(
+  totalPool: bigint,
+  voterRewardBps: number = VOTER_REWARD_BPS,
+): bigint {
+  return (totalPool * BigInt(voterRewardBps)) / BigInt(BPS_DENOMINATOR);
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts raw token base units to a human-readable decimal string.
+ * PredictX uses 7 decimal places (like Stellar's XLM stroops format).
+ *
+ * @param amount   - Raw amount in base units (bigint).
+ * @param decimals - Token decimal places (default 7).
+ * @returns Human-readable string, e.g. "100.0000000".
+ */
+export function formatTokenAmount(amount: bigint, decimals = 7): string {
+  const divisor = 10n ** BigInt(decimals);
+  const whole = amount / divisor;
+  const fraction = amount % divisor;
+  const fracStr = fraction.toString().padStart(decimals, "0");
+  return `${whole}.${fracStr}`;
+}
+
+/**
+ * Parses a human-readable token string back to raw base units.
+ *
+ * @param value    - e.g. "100.5" or "100"
+ * @param decimals - Token decimal places (default 7).
+ * @returns Raw amount as bigint.
+ */
+export function parseTokenAmount(value: string, decimals = 7): bigint {
+  const [whole, fraction = ""] = value.split(".");
+  const paddedFraction = fraction.slice(0, decimals).padEnd(decimals, "0");
+  return BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFraction);
+}

--- a/predictx-sdk/src/utils/constants.ts
+++ b/predictx-sdk/src/utils/constants.ts
@@ -1,0 +1,35 @@
+/** Platform fee in basis points (5%). Mirrors `PLATFORM_FEE_BPS` in shared crate. */
+export const PLATFORM_FEE_BPS = 500;
+
+/** Voter reward reservation in basis points (1%). Mirrors `VOTER_REWARD_BPS`. */
+export const VOTER_REWARD_BPS = 100;
+
+/** Basis-point denominator (10 000 = 100%). */
+export const BPS_DENOMINATOR = 10_000;
+
+/** Voting window after poll locks (seconds) — 2 hours. */
+export const VOTING_WINDOW_SECS = 7_200;
+
+/** Dispute window (seconds) — 24 hours. */
+export const DISPUTE_WINDOW_SECS = 86_400;
+
+/** Consensus threshold for auto-resolve (85%). */
+export const AUTO_RESOLVE_THRESHOLD_BPS = 8_500;
+
+/** Minimum consensus for admin review (60%). */
+export const ADMIN_REVIEW_THRESHOLD_BPS = 6_000;
+
+/** Multi-sig threshold for admin actions. */
+export const MULTI_SIG_REQUIRED = 3;
+
+/** Maximum poll question length (characters). */
+export const MAX_QUESTION_LENGTH = 256;
+
+/** Maximum polls allowed per match. */
+export const MAX_POLLS_PER_MATCH = 50;
+
+/** Emergency refund timeout — 7 days (seconds). */
+export const EMERGENCY_TIMEOUT_SECS = 604_800;
+
+/** Minimum stake amount in base units (10 tokens @ 7 decimals). */
+export const MIN_STAKE_AMOUNT = 10_000_000n;

--- a/predictx-sdk/src/utils/formatting.ts
+++ b/predictx-sdk/src/utils/formatting.ts
@@ -1,0 +1,63 @@
+/**
+ * PredictX SDK — Formatting utilities for display strings.
+ */
+
+/**
+ * Truncates a Stellar address for display (e.g. "GABCD…WXYZ").
+ *
+ * @param address - Full Stellar account or contract ID.
+ * @param start   - Characters to keep at the start (default 6).
+ * @param end     - Characters to keep at the end (default 4).
+ */
+export function truncateAddress(
+  address: string,
+  start = 6,
+  end = 4,
+): string {
+  if (address.length <= start + end) return address;
+  return `${address.slice(0, start)}…${address.slice(-end)}`;
+}
+
+/**
+ * Formats a `Date` as a human-readable local datetime string.
+ *
+ * @param date   - Date to format.
+ * @param locale - BCP-47 locale string (default "en-US").
+ */
+export function formatDate(date: Date, locale = "en-US"): string {
+  return date.toLocaleString(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Returns a countdown string like "2h 15m" or "Expired" for a future date.
+ *
+ * @param target - Target date to count down to.
+ */
+export function formatCountdown(target: Date): string {
+  const diffMs = target.getTime() - Date.now();
+  if (diffMs <= 0) return "Expired";
+
+  const totalSecs = Math.floor(diffMs / 1000);
+  const days = Math.floor(totalSecs / 86_400);
+  const hours = Math.floor((totalSecs % 86_400) / 3_600);
+  const minutes = Math.floor((totalSecs % 3_600) / 60);
+
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+/**
+ * Formats a percentage (e.g. from `roi`) to two decimal places.
+ *
+ * @param value - Percentage value as a plain number.
+ */
+export function formatPercent(value: number): string {
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
+}

--- a/predictx-sdk/tests/calculations.test.ts
+++ b/predictx-sdk/tests/calculations.test.ts
@@ -1,0 +1,182 @@
+import {
+  calculatePotentialWinnings,
+  calculateClaimableWinnings,
+  calculatePlatformFee,
+  calculateVoterRewardPool,
+  formatTokenAmount,
+  parseTokenAmount,
+} from "../src/utils/calculations";
+import { PLATFORM_FEE_BPS, VOTER_REWARD_BPS } from "../src/utils/constants";
+
+// ---------------------------------------------------------------------------
+// calculatePotentialWinnings
+// ---------------------------------------------------------------------------
+
+describe("calculatePotentialWinnings", () => {
+  const yesPool = 1_000_000_000n; // 100 tokens
+  const noPool  = 1_000_000_000n; // 100 tokens
+
+  it("returns zero values for zero stake", () => {
+    const result = calculatePotentialWinnings(0n, "yes", yesPool, noPool);
+    expect(result.winnings).toBe(0n);
+    expect(result.profit).toBe(0n);
+    expect(result.roi).toBe(0);
+  });
+
+  it("returns zero values for negative stake", () => {
+    const result = calculatePotentialWinnings(-1n, "yes", yesPool, noPool);
+    expect(result.winnings).toBe(0n);
+  });
+
+  it("winnings >= stake for YES stake on equal pools", () => {
+    const stake = 100_000_000n; // 10 tokens
+    const result = calculatePotentialWinnings(stake, "yes", yesPool, noPool);
+    expect(result.winnings).toBeGreaterThan(stake);
+    expect(result.profit).toBeGreaterThan(0n);
+    expect(result.roi).toBeGreaterThan(0);
+  });
+
+  it("winnings >= stake for NO stake on equal pools", () => {
+    const stake = 100_000_000n;
+    const result = calculatePotentialWinnings(stake, "no", yesPool, noPool);
+    expect(result.winnings).toBeGreaterThan(stake);
+  });
+
+  it("deducts platform fee and voter reward from distributable", () => {
+    const stake = 1_000_000_000n; // 100 tokens
+    const empty = 0n;
+    const totalPool = yesPool + noPool + stake;
+    const result = calculatePotentialWinnings(stake, "yes", yesPool, empty);
+
+    // With empty noPool, the staker staking on YES gets almost all distributable
+    const totalDeductions = BigInt(PLATFORM_FEE_BPS + VOTER_REWARD_BPS);
+    const distributable = totalPool - (totalPool * totalDeductions) / 10_000n;
+    // Winnings should be approximately distributable * stake / (yesPool + stake)
+    expect(result.winnings).toBeLessThan(totalPool);
+    expect(result.winnings).toBeGreaterThan(0n);
+  });
+
+  it("roi matches profit/stake ratio", () => {
+    const stake = 500_000_000n;
+    const result = calculatePotentialWinnings(stake, "yes", yesPool, noPool);
+    const expectedRoi = Number((result.profit * 10_000n) / stake) / 100;
+    expect(result.roi).toBeCloseTo(expectedRoi, 5);
+  });
+
+  it("respects custom feeBps", () => {
+    const stake = 100_000_000n;
+    const zeroFee = calculatePotentialWinnings(stake, "yes", yesPool, noPool, 0, 0);
+    const withFee = calculatePotentialWinnings(stake, "yes", yesPool, noPool, 1000, 0);
+    expect(zeroFee.winnings).toBeGreaterThan(withFee.winnings);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateClaimableWinnings
+// ---------------------------------------------------------------------------
+
+describe("calculateClaimableWinnings", () => {
+  it("returns 0 when stakePool is 0", () => {
+    expect(calculateClaimableWinnings(100n, 0n, 500n)).toBe(0n);
+  });
+
+  it("proportional share of distributable pool", () => {
+    const stakeAmount = 500_000_000n;
+    const stakePool   = 1_000_000_000n;
+    const totalPool   = 2_000_000_000n;
+    const feeBps  = 500;
+    const voterBps = 100;
+    const totalDeductions = BigInt(feeBps + voterBps);
+    const distributable = totalPool - (totalPool * totalDeductions) / 10_000n;
+    const expected = (stakeAmount * distributable) / stakePool;
+
+    expect(calculateClaimableWinnings(stakeAmount, stakePool, totalPool, feeBps, voterBps)).toBe(expected);
+  });
+
+  it("full stake pool returns full distributable", () => {
+    const stakeAmount = 1_000_000_000n;
+    const stakePool   = 1_000_000_000n;
+    const totalPool   = 2_000_000_000n;
+    const result = calculateClaimableWinnings(stakeAmount, stakePool, totalPool, 0, 0);
+    expect(result).toBe(totalPool);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculatePlatformFee
+// ---------------------------------------------------------------------------
+
+describe("calculatePlatformFee", () => {
+  it("computes 5% fee correctly", () => {
+    expect(calculatePlatformFee(10_000_000n, 500)).toBe(500_000n);
+  });
+
+  it("returns 0 for zero pool", () => {
+    expect(calculatePlatformFee(0n)).toBe(0n);
+  });
+
+  it("uses default PLATFORM_FEE_BPS", () => {
+    const pool = 20_000_000n;
+    const expected = (pool * BigInt(PLATFORM_FEE_BPS)) / 10_000n;
+    expect(calculatePlatformFee(pool)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateVoterRewardPool
+// ---------------------------------------------------------------------------
+
+describe("calculateVoterRewardPool", () => {
+  it("computes 1% voter reward", () => {
+    expect(calculateVoterRewardPool(10_000_000n, 100)).toBe(100_000n);
+  });
+
+  it("uses default VOTER_REWARD_BPS", () => {
+    const pool = 30_000_000n;
+    const expected = (pool * BigInt(VOTER_REWARD_BPS)) / 10_000n;
+    expect(calculateVoterRewardPool(pool)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatTokenAmount / parseTokenAmount
+// ---------------------------------------------------------------------------
+
+describe("formatTokenAmount", () => {
+  it("formats whole tokens", () => {
+    expect(formatTokenAmount(10_000_000n)).toBe("1.0000000");
+  });
+
+  it("formats fractional tokens", () => {
+    expect(formatTokenAmount(10_000_001n)).toBe("1.0000001");
+  });
+
+  it("formats zero", () => {
+    expect(formatTokenAmount(0n)).toBe("0.0000000");
+  });
+
+  it("formats large amounts", () => {
+    expect(formatTokenAmount(1_000_000_000_000n)).toBe("100000.0000000");
+  });
+});
+
+describe("parseTokenAmount", () => {
+  it("parses whole number strings", () => {
+    expect(parseTokenAmount("1")).toBe(10_000_000n);
+  });
+
+  it("parses decimal strings", () => {
+    expect(parseTokenAmount("1.5")).toBe(15_000_000n);
+  });
+
+  it("parses zero", () => {
+    expect(parseTokenAmount("0")).toBe(0n);
+  });
+
+  it("round-trips with formatTokenAmount", () => {
+    const amount = 123_456_789n;
+    const formatted = formatTokenAmount(amount);
+    const parsed = parseTokenAmount(formatted);
+    expect(parsed).toBe(amount);
+  });
+});

--- a/predictx-sdk/tests/errors.test.ts
+++ b/predictx-sdk/tests/errors.test.ts
@@ -1,0 +1,49 @@
+import { PredictXError, PredictXErrorCode, parseSorobanError } from "../src/errors";
+
+describe("PredictXError", () => {
+  it("sets name to 'PredictXError'", () => {
+    const err = new PredictXError(PredictXErrorCode.PollNotFound);
+    expect(err.name).toBe("PredictXError");
+  });
+
+  it("includes a descriptive message", () => {
+    const err = new PredictXError(PredictXErrorCode.PollNotFound);
+    expect(err.message).toContain("Poll not found");
+  });
+
+  it("appends context to message when provided", () => {
+    const err = new PredictXError(PredictXErrorCode.Unauthorized, "only admin");
+    expect(err.message).toContain("only admin");
+  });
+
+  it("exposes the numeric code", () => {
+    const err = new PredictXError(PredictXErrorCode.StakeBelowMinimum);
+    expect(err.code).toBe(PredictXErrorCode.StakeBelowMinimum);
+  });
+});
+
+describe("parseSorobanError", () => {
+  it("returns PredictXError as-is", () => {
+    const err = new PredictXError(PredictXErrorCode.AlreadyStaked);
+    expect(parseSorobanError(err)).toBe(err);
+  });
+
+  it("parses contract error code from Soroban message format", () => {
+    const raw = new Error("HostError: Error(Contract, #11)");
+    const parsed = parseSorobanError(raw);
+    expect(parsed).toBeInstanceOf(PredictXError);
+    expect((parsed as PredictXError).code).toBe(PredictXErrorCode.AlreadyStaked);
+  });
+
+  it("wraps unknown errors in a generic Error", () => {
+    const parsed = parseSorobanError("unexpected string error");
+    expect(parsed).toBeInstanceOf(Error);
+    expect(parsed.message).toContain("unexpected string error");
+  });
+
+  it("returns the original Error when code is unrecognised", () => {
+    const raw = new Error("Some network error");
+    const parsed = parseSorobanError(raw);
+    expect(parsed).toBe(raw);
+  });
+});

--- a/predictx-sdk/tests/events.test.ts
+++ b/predictx-sdk/tests/events.test.ts
@@ -1,0 +1,115 @@
+import { parseEvent } from "../src/events/parser";
+import { PollCategory, StakeSide } from "../src/types/index";
+
+function makeEvent(category: string, action: string, data: Record<string, unknown>) {
+  return {
+    type: "contract",
+    topic: [
+      { type: "symbol", value: category },
+      { type: "symbol", value: action },
+    ],
+    value: { type: "map", value: data },
+  };
+}
+
+describe("parseEvent", () => {
+  it("parses poll:created events", () => {
+    const raw = makeEvent("poll", "created", {
+      poll_id: 1,
+      match_id: 2,
+      creator: "GABCDE",
+      question: "Will Chelsea win?",
+      category: PollCategory.TeamEvent,
+      lock_time: 1_700_000_000,
+    });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("poll:created");
+    if (event?.type === "poll:created") {
+      expect(event.pollId).toBe(1);
+      expect(event.question).toBe("Will Chelsea win?");
+      expect(event.lockTime).toBeInstanceOf(Date);
+    }
+  });
+
+  it("parses stake:placed events", () => {
+    const raw = makeEvent("stake", "placed", {
+      poll_id: 5,
+      staker: "GXXX",
+      amount: "100000000",
+      side: StakeSide.Yes,
+    });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("stake:placed");
+    if (event?.type === "stake:placed") {
+      expect(event.pollId).toBe(5);
+      expect(event.amount).toBe(100_000_000n);
+      expect(event.side).toBe(StakeSide.Yes);
+    }
+  });
+
+  it("parses poll:cancelled events", () => {
+    const raw = makeEvent("poll", "cancelled", {
+      poll_id: 3,
+      admin: "GADMIN",
+    });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("poll:cancelled");
+    if (event?.type === "poll:cancelled") {
+      expect(event.pollId).toBe(3);
+      expect(event.admin).toBe("GADMIN");
+    }
+  });
+
+  it("parses match:created events", () => {
+    const raw = makeEvent("match", "created", {
+      match_id: 10,
+      home_team: "Arsenal",
+      away_team: "Chelsea",
+    });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("match:created");
+    if (event?.type === "match:created") {
+      expect(event.matchId).toBe(10);
+      expect(event.homeTeam).toBe("Arsenal");
+    }
+  });
+
+  it("parses stake:emergency_withdrawal events", () => {
+    const raw = makeEvent("stake", "emergency_withdrawal", {
+      poll_id: 7,
+      user: "GUSER",
+      amount: "50000000",
+    });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("stake:emergency_withdrawal");
+    if (event?.type === "stake:emergency_withdrawal") {
+      expect(event.amount).toBe(50_000_000n);
+    }
+  });
+
+  it("parses contract:paused events", () => {
+    const raw = makeEvent("contract", "paused", { admin: "GADMIN2" });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("contract:paused");
+  });
+
+  it("parses contract:unpaused events", () => {
+    const raw = makeEvent("contract", "unpaused", { admin: "GADMIN2" });
+    const event = parseEvent(raw as any);
+    expect(event?.type).toBe("contract:unpaused");
+  });
+
+  it("returns null for unknown event types", () => {
+    const raw = makeEvent("unknown", "action", {});
+    expect(parseEvent(raw as any)).toBeNull();
+  });
+
+  it("returns null for events with too few topics", () => {
+    const raw = {
+      type: "contract",
+      topic: [{ type: "symbol", value: "poll" }],
+      value: { type: "map", value: {} },
+    };
+    expect(parseEvent(raw as any)).toBeNull();
+  });
+});

--- a/predictx-sdk/tests/formatting.test.ts
+++ b/predictx-sdk/tests/formatting.test.ts
@@ -1,0 +1,72 @@
+import {
+  truncateAddress,
+  formatDate,
+  formatCountdown,
+  formatPercent,
+} from "../src/utils/formatting";
+
+describe("truncateAddress", () => {
+  const addr = "GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  it("truncates long addresses", () => {
+    const result = truncateAddress(addr);
+    expect(result).toContain("…");
+    expect(result.startsWith("GABCDE")).toBe(true);
+  });
+
+  it("returns address unchanged if short", () => {
+    expect(truncateAddress("GABCD")).toBe("GABCD");
+  });
+
+  it("respects custom start/end lengths", () => {
+    const result = truncateAddress(addr, 4, 4);
+    expect(result).toMatch(/^GABC…/);
+  });
+});
+
+describe("formatDate", () => {
+  it("returns a non-empty string for a valid date", () => {
+    const result = formatDate(new Date("2025-06-15T12:00:00Z"));
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatCountdown", () => {
+  it("returns 'Expired' for past dates", () => {
+    const past = new Date(Date.now() - 1000);
+    expect(formatCountdown(past)).toBe("Expired");
+  });
+
+  it("shows minutes for near-future dates", () => {
+    const future = new Date(Date.now() + 5 * 60 * 1000); // 5 minutes
+    const result = formatCountdown(future);
+    expect(result).toMatch(/\dm/);
+  });
+
+  it("shows hours for medium-future dates", () => {
+    const future = new Date(Date.now() + 3 * 3600 * 1000); // 3 hours
+    const result = formatCountdown(future);
+    expect(result).toMatch(/h/);
+  });
+
+  it("shows days for far-future dates", () => {
+    const future = new Date(Date.now() + 3 * 86_400 * 1000); // 3 days
+    const result = formatCountdown(future);
+    expect(result).toMatch(/d/);
+  });
+});
+
+describe("formatPercent", () => {
+  it("shows + for positive ROI", () => {
+    expect(formatPercent(12.5)).toBe("+12.50%");
+  });
+
+  it("shows - for negative ROI", () => {
+    expect(formatPercent(-5.2)).toBe("-5.20%");
+  });
+
+  it("formats zero", () => {
+    expect(formatPercent(0)).toBe("+0.00%");
+  });
+});

--- a/predictx-sdk/tsconfig.json
+++ b/predictx-sdk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary

- Implements a full npm-ready `@predictx/sdk` TypeScript package inside `predictx-sdk/`
- Wraps all four Soroban contracts (PredictionMarket, VotingOracle, Treasury, PollFactory) in typed, ergonomic client classes
- Top-level `PredictXClient` aggregates all contracts into the methods the frontend needs (browse → stake → vote → claim flow)
- All on-chain types mirrored exactly: `bigint` for `i128`, `number` for `u32`/`u64`, `Date` for Unix timestamps
- Client-side `calculatePotentialWinnings` replicates contract math for instant UI previews
- Typed Soroban event parser for all 7 PredictX event types with real-time subscription
- `PredictXError` maps all 34 on-chain error codes to descriptive TypeScript errors
- Utility functions: `formatTokenAmount`, `parseTokenAmount`, `truncateAddress`, `formatCountdown`
- Dual CJS + ESM output — works in Node.js ≥ 18 and modern browsers

## Test plan

- [ ] Unit tests for `calculatePotentialWinnings` (8 cases including edge cases)
- [ ] Unit tests for `calculateClaimableWinnings`, fee helpers
- [ ] Unit tests for `formatTokenAmount` / `parseTokenAmount` round-trip
- [ ] Unit tests for `PredictXError` construction and `parseSorobanError`
- [ ] Unit tests for event parser — all 7 event types + unknown/malformed events
- [ ] Unit tests for formatting utilities (`truncateAddress`, `formatCountdown`, `formatPercent`)
- [ ] Run `npm test` inside `predictx-sdk/` after `npm install`

Closes #26
