### PR TITLE
feat: implement super admin role and access control across contracts.

### DIFF
--- a/contracts/poll-factory/src/lib.rs
+++ b/contracts/poll-factory/src/lib.rs
@@ -1,6 +1,11 @@
 #![no_std]
 
-use predictx_shared::{PredictXError, Poll, PollCategory, PollStatus};
+use predictx_shared::{
+    add_admin as shared_add_admin, get_admins as shared_get_admins,
+    get_super_admin as shared_get_super_admin, is_admin as shared_is_admin,
+    remove_admin as shared_remove_admin,
+    DataKey as SharedDataKey, PredictXError, Poll, PollCategory, PollStatus,
+};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
 
 #[contract]
@@ -15,10 +20,7 @@ enum DataKey {
 }
 
 fn get_admin(env: &Env) -> Result<Address, PredictXError> {
-    env.storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(PredictXError::NotInitialized)
+    shared_get_super_admin(env)
 }
 
 fn next_poll_id(env: &Env) -> u64 {
@@ -40,12 +42,34 @@ impl PollFactory {
 
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&SharedDataKey::SuperAdmin, &admin);
+        env.storage().instance().set(&SharedDataKey::AdminList, &soroban_sdk::Vec::<Address>::new(&env));
         env.storage().instance().set(&DataKey::NextPollId, &1_u64);
         Ok(())
     }
 
     pub fn admin(env: Env) -> Result<Address, PredictXError> {
         get_admin(&env)
+    }
+
+    pub fn get_super_admin(env: Env) -> Result<Address, PredictXError> {
+        shared_get_super_admin(&env)
+    }
+
+    pub fn get_admins(env: Env) -> soroban_sdk::Vec<Address> {
+        shared_get_admins(&env)
+    }
+
+    pub fn is_admin(env: Env, address: Address) -> Result<bool, PredictXError> {
+        shared_is_admin(&env, &address)
+    }
+
+    pub fn add_admin(env: Env, super_admin: Address, new_admin: Address) -> Result<(), PredictXError> {
+        shared_add_admin(&env, &super_admin, new_admin)
+    }
+
+    pub fn remove_admin(env: Env, super_admin: Address, admin_to_remove: Address) -> Result<(), PredictXError> {
+        shared_remove_admin(&env, &super_admin, admin_to_remove)
     }
 
     pub fn create_poll(
@@ -121,5 +145,25 @@ mod test {
         assert_eq!(poll.question, question);
         assert_eq!(poll.status, PollStatus::Active);
         assert_eq!(poll.lock_time, 123_u64);
+    }
+
+    #[test]
+    fn only_super_admin_can_manage_admins() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PollFactory, ());
+        let client = PollFactoryClient::new(&env, &contract_id);
+
+        let super_admin = Address::generate(&env);
+        client.initialize(&super_admin);
+        let attacker = Address::generate(&env);
+        let admin = Address::generate(&env);
+
+        let err = client
+            .try_add_admin(&attacker, &admin)
+            .expect_err("only super admin can add");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
+        client.add_admin(&super_admin, &admin);
+        assert!(client.is_admin(&admin));
     }
 }

--- a/contracts/prediction-market/src/lib.rs
+++ b/contracts/prediction-market/src/lib.rs
@@ -5,7 +5,12 @@ mod staking;
 pub(crate) mod token_utils;
 
 use predictx_shared::{
-    Match, PlatformStats, Poll, PollCategory, PollStatus, PredictXError, Stake, StakeSide,
+    accept_super_admin_transfer, add_admin as shared_add_admin, get_admins as shared_get_admins,
+    get_oracle as shared_get_oracle, get_super_admin as shared_get_super_admin,
+    is_admin as shared_is_admin,
+    propose_super_admin_transfer, remove_admin as shared_remove_admin, require_admin,
+    set_oracle as shared_set_oracle, DataKey as SharedDataKey, Match,
+    PlatformStats, Poll, PollCategory, PollStatus, PredictXError, Stake, StakeSide,
     MAX_POLLS_PER_MATCH,
 };
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
@@ -65,13 +70,11 @@ pub struct PoolInfo {
 }
 
 fn get_admin(env: &Env) -> Result<Address, PredictXError> {
-    env.storage().instance().get(&DataKey::Admin)
-        .ok_or(PredictXError::NotInitialized)
+    shared_get_super_admin(env)
 }
 
 fn get_oracle(env: &Env) -> Result<Address, PredictXError> {
-    env.storage().instance().get(&DataKey::VotingOracle)
-        .ok_or(PredictXError::NotInitialized)
+    shared_get_oracle(env)
 }
 
 fn is_paused(env: &Env) -> bool {
@@ -133,6 +136,9 @@ impl PredictionMarket {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::VotingOracle, &voting_oracle);
+        env.storage().instance().set(&SharedDataKey::SuperAdmin, &admin);
+        env.storage().instance().set(&SharedDataKey::OracleAddress, &voting_oracle);
+        env.storage().instance().set(&SharedDataKey::AdminList, &Vec::<Address>::new(&env));
         env.storage().instance().set(&DataKey::TokenAddress, &token_address);
         env.storage().instance().set(&DataKey::TreasuryAddress, &treasury_address);
         env.storage().instance().set(&DataKey::PlatformFeeBps, &platform_fee_bps);
@@ -143,29 +149,54 @@ impl PredictionMarket {
     }
 
     pub fn admin(env: Env) -> Result<Address, PredictXError> { get_admin(&env) }
+    pub fn get_super_admin(env: Env) -> Result<Address, PredictXError> { shared_get_super_admin(&env) }
+    pub fn get_admins(env: Env) -> Vec<Address> { shared_get_admins(&env) }
+    pub fn is_admin(env: Env, address: Address) -> Result<bool, PredictXError> {
+        shared_is_admin(&env, &address)
+    }
     pub fn oracle(env: Env) -> Result<Address, PredictXError> { get_oracle(&env) }
 
-    pub fn set_oracle(env: Env, voting_oracle: Address) -> Result<(), PredictXError> {
+    pub fn set_oracle(env: Env, super_admin: Address, voting_oracle: Address) -> Result<(), PredictXError> {
         ensure_not_paused(&env)?;
-        let admin = get_admin(&env)?;
-        admin.require_auth();
+        shared_set_oracle(&env, &super_admin, voting_oracle.clone())?;
         env.storage().instance().set(&DataKey::VotingOracle, &voting_oracle);
+        env.events().publish((Symbol::new(&env, "OracleSet"),), voting_oracle);
+        Ok(())
+    }
+
+    pub fn add_admin(env: Env, super_admin: Address, new_admin: Address) -> Result<(), PredictXError> {
+        shared_add_admin(&env, &super_admin, new_admin.clone())?;
+        env.events().publish((Symbol::new(&env, "AdminAdded"),), new_admin);
+        Ok(())
+    }
+
+    pub fn remove_admin(env: Env, super_admin: Address, admin_to_remove: Address) -> Result<(), PredictXError> {
+        shared_remove_admin(&env, &super_admin, admin_to_remove.clone())?;
+        env.events().publish((Symbol::new(&env, "AdminRemoved"),), admin_to_remove);
+        Ok(())
+    }
+
+    pub fn propose_super_admin_transfer(env: Env, super_admin: Address, new_super_admin: Address) -> Result<(), PredictXError> {
+        propose_super_admin_transfer(&env, &super_admin, new_super_admin.clone())?;
+        env.events().publish((Symbol::new(&env, "SuperAdminTransferProposed"),), new_super_admin);
+        Ok(())
+    }
+
+    pub fn accept_super_admin_transfer(env: Env, pending_super_admin: Address) -> Result<(), PredictXError> {
+        accept_super_admin_transfer(&env, &pending_super_admin)?;
+        env.events().publish((Symbol::new(&env, "SuperAdminTransferred"),), pending_super_admin);
         Ok(())
     }
 
     pub fn pause(env: Env, admin: Address) -> Result<(), PredictXError> {
-        let stored_admin = get_admin(&env)?;
-        if admin != stored_admin { return Err(PredictXError::Unauthorized); }
-        admin.require_auth();
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish((Symbol::new(&env, "ContractPaused"),), true);
         Ok(())
     }
 
     pub fn unpause(env: Env, admin: Address) -> Result<(), PredictXError> {
-        let stored_admin = get_admin(&env)?;
-        if admin != stored_admin { return Err(PredictXError::Unauthorized); }
-        admin.require_auth();
+        require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events().publish((Symbol::new(&env, "ContractUnpaused"),), true);
         Ok(())
@@ -181,12 +212,10 @@ impl PredictionMarket {
 
     pub fn cancel_poll(env: Env, admin: Address, poll_id: u64) -> Result<(), PredictXError> {
         ensure_not_paused(&env)?;
-        let stored_admin = get_admin(&env)?;
-        if admin != stored_admin { return Err(PredictXError::Unauthorized); }
-        admin.require_auth();
+        require_admin(&env, &admin)?;
         let oracle_id = get_oracle(&env)?;
         let client = voting_oracle::Client::new(&env, &oracle_id);
-        client.set_poll_status(&poll_id, &voting_oracle::PollStatus::Cancelled);
+        client.set_poll_status(&admin, &poll_id, &voting_oracle::PollStatus::Cancelled);
         env.events().publish((Symbol::new(&env, "PollCancelled"),), poll_id);
         Ok(())
     }
@@ -486,7 +515,7 @@ mod test {
         let oracle_id = env.register(voting_oracle::WASM, ());
         let oracle_client = voting_oracle::Client::new(&env, &oracle_id);
         oracle_client.initialize(&admin);
-        oracle_client.set_poll_status(&7_u64, &voting_oracle::PollStatus::Resolved);
+        oracle_client.set_poll_status(&admin, &7_u64, &voting_oracle::PollStatus::Resolved);
         let contract_id = env.register(PredictionMarket, ());
         let client = PredictionMarketClient::new(&env, &contract_id);
         let tok = Address::generate(&env);
@@ -510,7 +539,7 @@ mod test {
         assert_eq!(client.is_paused(), false);
         client.pause(&admin);
         assert_eq!(client.is_paused(), true);
-        let err = client.try_set_oracle(&oracle).expect_err("should be blocked");
+        let err = client.try_set_oracle(&admin, &oracle).expect_err("should be blocked");
         assert_eq!(err, Ok(PredictXError::EmergencyWithdrawNotAllowed));
         client.unpause(&admin);
         assert_eq!(client.is_paused(), false);
@@ -564,8 +593,7 @@ mod test {
 
     #[test]
     fn emergency_withdraw_on_cancelled_poll_refunds_stake() {
-        let (env, admin, oracle_id, contract_id, client) = setup_emergency_env();
-        let oracle_client = voting_oracle::Client::new(&env, &oracle_id);
+        let (env, admin, _oracle_id, contract_id, client) = setup_emergency_env();
         let token_addr: Address = env.as_contract(&contract_id, || {
             env.storage().instance().get(&DataKey::TokenAddress).unwrap()
         });
@@ -599,7 +627,7 @@ mod test {
         });
 
         env.ledger().set_timestamp(100);
-        oracle_client.set_poll_status(&5_u64, &voting_oracle::PollStatus::Disputed);
+        oracle_client.set_poll_status(&_admin, &5_u64, &voting_oracle::PollStatus::Disputed);
 
         let user = Address::generate(&env);
         let amount: i128 = 25;
@@ -621,7 +649,7 @@ mod test {
         let oracle_client = voting_oracle::Client::new(&env, &oracle_id);
 
         env.ledger().set_timestamp(200);
-        oracle_client.set_poll_status(&2_u64, &voting_oracle::PollStatus::Locked);
+        oracle_client.set_poll_status(&_admin, &2_u64, &voting_oracle::PollStatus::Locked);
 
         let user = Address::generate(&env);
         let stake = Stake { user: user.clone(), poll_id: 2, amount: 30, side: StakeSide::Yes, claimed: false, staked_at: env.ledger().timestamp() };
@@ -643,7 +671,7 @@ mod test {
         });
 
         env.ledger().set_timestamp(300);
-        oracle_client.set_poll_status(&3_u64, &voting_oracle::PollStatus::Disputed);
+        oracle_client.set_poll_status(&_admin, &3_u64, &voting_oracle::PollStatus::Disputed);
 
         let user = Address::generate(&env);
         let amount: i128 = 40;
@@ -658,5 +686,72 @@ mod test {
         assert_eq!(refunded, amount);
         let err = client.try_emergency_withdraw(&user, &3_u64).expect_err("double withdrawal should fail");
         assert_eq!(err, Ok(PredictXError::AlreadyClaimed));
+    }
+
+    #[test]
+    fn super_admin_can_manage_admins_and_admin_can_pause() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PredictionMarket, ());
+        let client = PredictionMarketClient::new(&env, &contract_id);
+        let super_admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let tok = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&super_admin, &oracle, &tok, &treasury, &TEST_FEE_BPS);
+
+        let admin = Address::generate(&env);
+        client.add_admin(&super_admin, &admin);
+        assert!(client.is_admin(&admin));
+        client.pause(&admin);
+        assert!(client.is_paused());
+
+        client.remove_admin(&super_admin, &admin);
+        assert!(!client.is_admin(&admin));
+        let err = client.try_unpause(&admin).expect_err("removed admin cannot unpause");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
+    }
+
+    #[test]
+    fn non_super_admin_cannot_add_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PredictionMarket, ());
+        let client = PredictionMarketClient::new(&env, &contract_id);
+        let super_admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let tok = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&super_admin, &oracle, &tok, &treasury, &TEST_FEE_BPS);
+
+        let attacker = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        let err = client
+            .try_add_admin(&attacker, &new_admin)
+            .expect_err("unauthorized add should fail");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
+    }
+
+    #[test]
+    fn two_step_super_admin_transfer_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(PredictionMarket, ());
+        let client = PredictionMarketClient::new(&env, &contract_id);
+        let super_admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let tok = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&super_admin, &oracle, &tok, &treasury, &TEST_FEE_BPS);
+
+        let next_super_admin = Address::generate(&env);
+        client.propose_super_admin_transfer(&super_admin, &next_super_admin);
+        client.accept_super_admin_transfer(&next_super_admin);
+        assert_eq!(client.get_super_admin(), next_super_admin);
+
+        let err = client
+            .try_add_admin(&super_admin, &Address::generate(&env))
+            .expect_err("old super admin should lose privileges");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
     }
 }

--- a/contracts/prediction-market/src/matches.rs
+++ b/contracts/prediction-market/src/matches.rs
@@ -1,21 +1,6 @@
 use soroban_sdk::{Address, Env, String, Symbol, Vec};
-use predictx_shared::{Match, PredictXError};
+use predictx_shared::{require_admin, Match, PredictXError};
 use crate::DataKey;   // ← uses prediction-market's local DataKey, not shared one
-
-// ── Internal helper ───────────────────────────────────────────────────────────
-
-pub fn require_admin(env: &Env, caller: &Address) -> Result<(), PredictXError> {
-    caller.require_auth();
-    let admin: Address = env
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(PredictXError::NotInitialized)?;
-    if *caller != admin {
-        return Err(PredictXError::Unauthorized);
-    }
-    Ok(())
-}
 
 // ── Match functions ───────────────────────────────────────────────────────────
 

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 
-use predictx_shared::PredictXError;
+use predictx_shared::{
+    add_admin as shared_add_admin, get_admins as shared_get_admins,
+    get_super_admin as shared_get_super_admin, is_admin as shared_is_admin,
+    remove_admin as shared_remove_admin, DataKey as SharedDataKey, PredictXError,
+};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 #[contract]
@@ -14,10 +18,7 @@ enum DataKey {
 }
 
 fn get_admin(env: &Env) -> Result<Address, PredictXError> {
-    env.storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(PredictXError::NotInitialized)
+    shared_get_super_admin(env)
 }
 
 fn get_balance(env: &Env, who: &Address) -> i128 {
@@ -36,11 +37,33 @@ impl Treasury {
 
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&SharedDataKey::SuperAdmin, &admin);
+        env.storage().instance().set(&SharedDataKey::AdminList, &soroban_sdk::Vec::<Address>::new(&env));
         Ok(())
     }
 
     pub fn admin(env: Env) -> Result<Address, PredictXError> {
         get_admin(&env)
+    }
+
+    pub fn get_super_admin(env: Env) -> Result<Address, PredictXError> {
+        shared_get_super_admin(&env)
+    }
+
+    pub fn get_admins(env: Env) -> soroban_sdk::Vec<Address> {
+        shared_get_admins(&env)
+    }
+
+    pub fn is_admin(env: Env, address: Address) -> Result<bool, PredictXError> {
+        shared_is_admin(&env, &address)
+    }
+
+    pub fn add_admin(env: Env, super_admin: Address, new_admin: Address) -> Result<(), PredictXError> {
+        shared_add_admin(&env, &super_admin, new_admin)
+    }
+
+    pub fn remove_admin(env: Env, super_admin: Address, admin_to_remove: Address) -> Result<(), PredictXError> {
+        shared_remove_admin(&env, &super_admin, admin_to_remove)
     }
 
     /// Placeholder accounting method.
@@ -93,5 +116,24 @@ mod test {
         assert_eq!(client.deposit(&user, &10_i128), 10_i128);
         assert_eq!(client.deposit(&user, &5_i128), 15_i128);
         assert_eq!(client.balance(&user), 15_i128);
+    }
+
+    #[test]
+    fn only_super_admin_can_add_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Treasury, ());
+        let client = TreasuryClient::new(&env, &contract_id);
+
+        let super_admin = Address::generate(&env);
+        client.initialize(&super_admin);
+        let attacker = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let err = client
+            .try_add_admin(&attacker, &admin)
+            .expect_err("only super admin can add");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
+        client.add_admin(&super_admin, &admin);
+        assert!(client.is_admin(&admin));
     }
 }

--- a/contracts/voting-oracle/src/lib.rs
+++ b/contracts/voting-oracle/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 
-use predictx_shared::{PredictXError, PollStatus};
+use predictx_shared::{
+    accept_super_admin_transfer, get_oracle as shared_get_oracle,
+    get_super_admin as shared_get_super_admin, propose_super_admin_transfer, require_oracle,
+    set_oracle as shared_set_oracle, DataKey as SharedDataKey, PredictXError, PollStatus,
+};
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 #[contract]
@@ -15,41 +19,47 @@ struct StoredPollStatus {
 
 #[contracttype]
 #[derive(Clone)]
-enum DataKey {
-    Admin,
-    PollStatus(u64),
-}
-
-fn get_admin(env: &Env) -> Result<Address, PredictXError> {
-    env.storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .ok_or(PredictXError::NotInitialized)
-}
+enum DataKey { PollStatus(u64) }
 
 #[contractimpl]
 impl VotingOracle {
-    pub fn initialize(env: Env, admin: Address) -> Result<(), PredictXError> {
-        if env.storage().instance().has(&DataKey::Admin) {
+    pub fn initialize(env: Env, super_admin: Address) -> Result<(), PredictXError> {
+        if env.storage().instance().has(&SharedDataKey::SuperAdmin) {
             return Err(PredictXError::AlreadyInitialized);
         }
-        admin.require_auth();
-
-        env.storage().instance().set(&DataKey::Admin, &admin);
+        super_admin.require_auth();
+        env.storage().instance().set(&SharedDataKey::SuperAdmin, &super_admin);
+        env.storage().instance().set(&SharedDataKey::OracleAddress, &super_admin);
         Ok(())
     }
 
-    pub fn admin(env: Env) -> Result<Address, PredictXError> {
-        get_admin(&env)
+    pub fn get_super_admin(env: Env) -> Result<Address, PredictXError> {
+        shared_get_super_admin(&env)
+    }
+
+    pub fn oracle(env: Env) -> Result<Address, PredictXError> {
+        shared_get_oracle(&env)
+    }
+
+    pub fn set_oracle(env: Env, super_admin: Address, oracle: Address) -> Result<(), PredictXError> {
+        shared_set_oracle(&env, &super_admin, oracle)?;
+        Ok(())
+    }
+
+    pub fn propose_super_admin_transfer(env: Env, super_admin: Address, new_super_admin: Address) -> Result<(), PredictXError> {
+        propose_super_admin_transfer(&env, &super_admin, new_super_admin)
+    }
+
+    pub fn accept_super_admin_transfer(env: Env, pending_super_admin: Address) -> Result<(), PredictXError> {
+        accept_super_admin_transfer(&env, &pending_super_admin)
     }
 
     /// Placeholder oracle state setter.
     ///
     /// This exists only to validate cross-contract invocation patterns during
     /// Phase 1 scaffolding.
-    pub fn set_poll_status(env: Env, poll_id: u64, status: PollStatus) -> Result<(), PredictXError> {
-        let admin = get_admin(&env)?;
-        admin.require_auth();
+    pub fn set_poll_status(env: Env, oracle: Address, poll_id: u64, status: PollStatus) -> Result<(), PredictXError> {
+        require_oracle(&env, &oracle)?;
 
         let stored = StoredPollStatus {
             status,
@@ -101,7 +111,39 @@ mod test {
         let admin = Address::generate(&env);
         client.initialize(&admin);
 
-        client.set_poll_status(&42_u64, &PollStatus::Resolved);
+        client.set_poll_status(&admin, &42_u64, &PollStatus::Resolved);
         assert_eq!(client.get_poll_status(&42_u64), PollStatus::Resolved);
+    }
+
+    #[test]
+    fn non_oracle_cannot_set_status() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(VotingOracle, ());
+        let client = VotingOracleClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        let stranger = Address::generate(&env);
+
+        let err = client
+            .try_set_poll_status(&stranger, &7_u64, &PollStatus::Cancelled)
+            .expect_err("non-oracle should fail");
+        assert_eq!(err, Ok(PredictXError::Unauthorized));
+    }
+
+    #[test]
+    fn two_step_super_admin_transfer_updates_control() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(VotingOracle, ());
+        let client = VotingOracleClient::new(&env, &contract_id);
+
+        let super_admin = Address::generate(&env);
+        let next_super_admin = Address::generate(&env);
+        client.initialize(&super_admin);
+        client.propose_super_admin_transfer(&super_admin, &next_super_admin);
+        client.accept_super_admin_transfer(&next_super_admin);
+        assert_eq!(client.get_super_admin(), next_super_admin);
     }
 }

--- a/packages/shared/src/access.rs
+++ b/packages/shared/src/access.rs
@@ -1,0 +1,125 @@
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::{DataKey, PredictXError};
+
+pub fn get_super_admin(env: &Env) -> Result<Address, PredictXError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::SuperAdmin)
+        .ok_or(PredictXError::NotInitialized)
+}
+
+pub fn get_oracle(env: &Env) -> Result<Address, PredictXError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::OracleAddress)
+        .ok_or(PredictXError::NotInitialized)
+}
+
+pub fn get_admins(env: &Env) -> Vec<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AdminList)
+        .unwrap_or(Vec::new(env))
+}
+
+pub fn is_admin(env: &Env, address: &Address) -> Result<bool, PredictXError> {
+    let super_admin = get_super_admin(env)?;
+    if *address == super_admin {
+        return Ok(true);
+    }
+    Ok(get_admins(env).contains(address))
+}
+
+pub fn require_super_admin(env: &Env, caller: &Address) -> Result<(), PredictXError> {
+    caller.require_auth();
+    let super_admin = get_super_admin(env)?;
+    if *caller != super_admin {
+        return Err(PredictXError::Unauthorized);
+    }
+    Ok(())
+}
+
+pub fn require_admin(env: &Env, caller: &Address) -> Result<(), PredictXError> {
+    caller.require_auth();
+    if !is_admin(env, caller)? {
+        return Err(PredictXError::Unauthorized);
+    }
+    Ok(())
+}
+
+pub fn require_oracle(env: &Env, caller: &Address) -> Result<(), PredictXError> {
+    caller.require_auth();
+    let oracle = get_oracle(env)?;
+    if *caller != oracle {
+        return Err(PredictXError::Unauthorized);
+    }
+    Ok(())
+}
+
+pub fn add_admin(env: &Env, caller: &Address, new_admin: Address) -> Result<(), PredictXError> {
+    require_super_admin(env, caller)?;
+    let mut admins = get_admins(env);
+    if admins.contains(&new_admin) {
+        return Err(PredictXError::AdminAlreadyRegistered);
+    }
+    admins.push_back(new_admin);
+    env.storage().instance().set(&DataKey::AdminList, &admins);
+    Ok(())
+}
+
+pub fn remove_admin(
+    env: &Env,
+    caller: &Address,
+    admin_to_remove: Address,
+) -> Result<(), PredictXError> {
+    require_super_admin(env, caller)?;
+    let admins = get_admins(env);
+    let mut next = Vec::new(env);
+    let mut found = false;
+    for admin in admins.iter() {
+        if admin == admin_to_remove {
+            found = true;
+        } else {
+            next.push_back(admin);
+        }
+    }
+    if !found {
+        return Err(PredictXError::Unauthorized);
+    }
+    env.storage().instance().set(&DataKey::AdminList, &next);
+    Ok(())
+}
+
+pub fn set_oracle(env: &Env, caller: &Address, oracle: Address) -> Result<(), PredictXError> {
+    require_super_admin(env, caller)?;
+    env.storage().instance().set(&DataKey::OracleAddress, &oracle);
+    Ok(())
+}
+
+pub fn propose_super_admin_transfer(
+    env: &Env,
+    caller: &Address,
+    new_super_admin: Address,
+) -> Result<(), PredictXError> {
+    require_super_admin(env, caller)?;
+    env.storage()
+        .instance()
+        .set(&DataKey::PendingSuperAdmin, &new_super_admin);
+    Ok(())
+}
+
+pub fn accept_super_admin_transfer(env: &Env, caller: &Address) -> Result<(), PredictXError> {
+    caller.require_auth();
+    let pending: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::PendingSuperAdmin)
+        .ok_or(PredictXError::Unauthorized)?;
+    if pending != *caller {
+        return Err(PredictXError::Unauthorized);
+    }
+    env.storage().instance().set(&DataKey::SuperAdmin, caller);
+    env.storage().instance().remove(&DataKey::PendingSuperAdmin);
+    Ok(())
+}

--- a/packages/shared/src/lib.rs
+++ b/packages/shared/src/lib.rs
@@ -1,11 +1,13 @@
 #![no_std]
 
 pub mod constants;
+pub mod access;
 pub mod errors;
 pub mod storage;
 pub mod types;
 
 pub use constants::*;
+pub use access::*;
 pub use errors::PredictXError;
 pub use storage::DataKey;
 pub use types::*;

--- a/packages/shared/src/storage.rs
+++ b/packages/shared/src/storage.rs
@@ -9,8 +9,14 @@ use soroban_sdk::{contracttype, Address};
 #[contracttype]
 pub enum DataKey {
     // ── Instance storage ──────────────────────────────────────────────────────
+    /// Super admin `Address`. (Instance)
+    SuperAdmin,
+    /// Pending super admin `Address` for 2-step transfer. (Instance)
+    PendingSuperAdmin,
     /// Admin `Address`. (Instance)
     Admin,
+    /// Oracle contract `Address`. (Instance)
+    OracleAddress,
     /// Soroban token contract `Address` used for staking. (Instance)
     TokenAddress,
     /// Platform fee in basis points. (Instance)

--- a/packages/shared/src/types.rs
+++ b/packages/shared/src/types.rs
@@ -54,6 +54,15 @@ pub enum VoteChoice {
     Unclear = 2,
 }
 
+/// Access-control roles used across PredictX contracts.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Role {
+    SuperAdmin = 0,
+    Admin = 1,
+    Oracle = 2,
+}
+
 // ── Structs ───────────────────────────────────────────────────────────────────
 
 /// A football match that polls are grouped under.


### PR DESCRIPTION
# Access control & role-based permissions

Closes #16 

## Summary

Introduces a shared RBAC layer (super admin, admin list, oracle address) and wires it through PredictX contracts so authentication (`require_auth`) and authorization (`require_*` against on-chain role storage) are consistent. Adds optional two-step super-admin transfer for safer key rotation and expands tests around privileged paths.

## What changed

### Shared package (`predictx-shared`)

- New `Role` enum (`SuperAdmin`, `Admin`, `Oracle`) in `types`.
- New instance storage keys: `SuperAdmin`, `PendingSuperAdmin`, `OracleAddress` (alongside existing `AdminList`).
- New `access` module with reusable helpers:
  - `require_super_admin`, `require_admin`, `require_oracle`
  - `get_super_admin`, `get_oracle`, `get_admins`, `is_admin`
  - `add_admin`, `remove_admin`, `set_oracle`
  - `propose_super_admin_transfer`, `accept_super_admin_transfer`

### Prediction market

- Initializes shared RBAC state on `initialize` (super admin, empty admin list, oracle address aligned with configured VotingOracle).
- Admin-only operations use shared `require_admin` (super admin still passes as admin).
- Super-admin-only: `add_admin`, `remove_admin`, `set_oracle`, propose/accept super-admin transfer.
- Governance-style events: `AdminAdded`, `AdminRemoved`, `OracleSet`, `SuperAdminTransferProposed`, `SuperAdminTransferred`.
- Match helpers use shared admin checks instead of a single local admin equality helper.

### Voting oracle

- Initialization seeds super admin and oracle role storage.
- `set_poll_status` is authorized for the **configured oracle identity** (caller must match stored oracle address and authenticate), not a generic admin-only gate.
- Exposes super-admin transfer and oracle configuration aligned with shared helpers.

### Poll factory & treasury

- `initialize` records super admin and admin list scaffold (same shared keys pattern).
- Super-admin-only admin list management APIs for consistency across the workspace.

### Tests

- Prediction market: super admin admin list CRUD, non–super-admin denial, two-step transfer, existing match/admin flows preserved.
- Voting oracle: non-oracle cannot set status; super-admin transfer.
- Poll factory / treasury: only super admin can add admins.

## Breaking changes

- **`PredictionMarket::set_oracle`** now takes `(super_admin, voting_oracle)` so the super-admin identity is explicit and authorization matches the matrix.
- **`VotingOracle::set_poll_status`** now takes the **oracle caller** address as the first argument after `env` (the identity that must match the stored oracle and sign the call).

Call sites and tests were updated accordingly.

## How to test

```bash
cargo test -p predictx-shared -p prediction-market -p voting-oracle -p poll-factory -p treasury
```

Optional full workspace:

```bash
cargo test --workspace
```

## Notes

- `cargo test` may report a **warning** for unused `transfer_to_treasury` in `prediction-market` (`token_utils.rs`); it is unrelated to RBAC behavior.
